### PR TITLE
운동 시작 및 종료 알림들을 받아오는 Flow구현, GroupRepository에 exitGroup 추가

### DIFF
--- a/data/src/main/java/com/whyranoid/data/constant/FieldId.kt
+++ b/data/src/main/java/com/whyranoid/data/constant/FieldId.kt
@@ -7,4 +7,5 @@ object FieldId {
     const val GROUP_NAME = "groupName"
     const val GROUP_INTRODUCE = "introduce"
     const val RULES = "rules"
+    const val JOINED_GROUP_LIST = "joinedGroupList"
 }

--- a/data/src/main/java/com/whyranoid/data/group/GroupRepositoryImpl.kt
+++ b/data/src/main/java/com/whyranoid/data/group/GroupRepositoryImpl.kt
@@ -32,6 +32,10 @@ class GroupRepositoryImpl @Inject constructor(
         return groupDataSource.joinGroup(uid, groupId)
     }
 
+    override suspend fun exitGroup(uid: String, groupId: String): Boolean {
+        return groupDataSource.joinGroup(uid, groupId)
+    }
+
     override fun getGroupNotifications(groupId: String): Flow<List<GroupNotification>> {
         return groupNotificationDataSource.getGroupNotifications(groupId)
     }

--- a/data/src/main/java/com/whyranoid/data/group/GroupRepositoryImpl.kt
+++ b/data/src/main/java/com/whyranoid/data/group/GroupRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package com.whyranoid.data.group
 
+import com.whyranoid.data.groupnotification.GroupNotificationDataSource
 import com.whyranoid.data.user.UserDataSource
 import com.whyranoid.domain.model.GroupInfo
 import com.whyranoid.domain.model.GroupNotification
@@ -10,7 +11,8 @@ import javax.inject.Inject
 
 class GroupRepositoryImpl @Inject constructor(
     private val userDataSource: UserDataSource,
-    private val groupDataSource: GroupDataSource
+    private val groupDataSource: GroupDataSource,
+    private val groupNotificationDataSource: GroupNotificationDataSource
 ) : GroupRepository {
 
     override suspend fun getMyGroupList(uid: String): Result<List<GroupInfo>> {
@@ -31,6 +33,6 @@ class GroupRepositoryImpl @Inject constructor(
     }
 
     override fun getGroupNotifications(groupId: String): Flow<List<GroupNotification>> {
-        TODO("Not yet implemented")
+        return groupNotificationDataSource.getGroupNotifications(groupId)
     }
 }

--- a/data/src/main/java/com/whyranoid/data/groupnotification/GroupNotificationDataSource.kt
+++ b/data/src/main/java/com/whyranoid/data/groupnotification/GroupNotificationDataSource.kt
@@ -1,0 +1,70 @@
+package com.whyranoid.data.groupnotification
+
+import com.google.firebase.firestore.FirebaseFirestore
+import com.whyranoid.data.constant.CollectionId.FINISH_NOTIFICATION
+import com.whyranoid.data.constant.CollectionId.GROUP_NOTIFICATIONS_COLLECTION
+import com.whyranoid.data.constant.CollectionId.START_NOTIFICATION
+import com.whyranoid.data.model.FinishNotificationResponse
+import com.whyranoid.data.model.StartNotificationResponse
+import com.whyranoid.data.model.toFinishNotification
+import com.whyranoid.data.model.toStartNotification
+import com.whyranoid.domain.model.GroupNotification
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.flattenMerge
+import kotlinx.coroutines.flow.flowOf
+import javax.inject.Inject
+
+class GroupNotificationDataSource @Inject constructor(
+    private val db: FirebaseFirestore
+) {
+
+    @OptIn(FlowPreview::class)
+    fun getGroupNotifications(groupId: String): Flow<List<GroupNotification>> {
+        val startNotificationFlow = getGroupStartNotifications(groupId)
+        val finishNotificationFlow = getGroupFinishNotifications(groupId)
+
+        return flowOf(
+            startNotificationFlow,
+            finishNotificationFlow
+        ).flattenMerge()
+    }
+
+    private fun getGroupStartNotifications(groupId: String): Flow<List<GroupNotification>> =
+        callbackFlow {
+            db.collection(GROUP_NOTIFICATIONS_COLLECTION)
+                .document(groupId)
+                .collection(START_NOTIFICATION)
+                .addSnapshotListener { snapshot, error ->
+                    val startNotificationList = mutableListOf<GroupNotification>()
+                    snapshot?.forEach { document ->
+                        val startNotification =
+                            document.toObject(StartNotificationResponse::class.java)
+                        startNotificationList.add(startNotification.toStartNotification())
+                    }
+                    trySend(startNotificationList)
+                }
+
+            awaitClose()
+        }
+
+    private fun getGroupFinishNotifications(groupId: String): Flow<List<GroupNotification>> =
+        callbackFlow {
+            db.collection(GROUP_NOTIFICATIONS_COLLECTION)
+                .document(groupId)
+                .collection(FINISH_NOTIFICATION)
+                .addSnapshotListener { snapshot, error ->
+                    val finishNotificationList = mutableListOf<GroupNotification>()
+                    snapshot?.forEach { document ->
+                        val finishNotification =
+                            document.toObject(FinishNotificationResponse::class.java)
+                        finishNotificationList.add(finishNotification.toFinishNotification())
+                    }
+                    trySend(finishNotificationList)
+                }
+
+            awaitClose()
+        }
+}

--- a/data/src/main/java/com/whyranoid/data/model/GroupNotificationResponse.kt
+++ b/data/src/main/java/com/whyranoid/data/model/GroupNotificationResponse.kt
@@ -1,0 +1,46 @@
+package com.whyranoid.data.model
+
+import com.whyranoid.domain.model.FinishNotification
+import com.whyranoid.domain.model.RunningHistory
+import com.whyranoid.domain.model.StartNotification
+
+sealed interface GroupNotificationResponse {
+    val type: String
+    val uid: String
+}
+
+data class StartNotificationResponse(
+    override val type: String = "",
+    override val uid: String = "",
+    val startedAt: Long = 0L
+) : GroupNotificationResponse
+
+data class FinishNotificationResponse(
+    override val type: String = "",
+    override val uid: String = "",
+    val finishedAt: Long = 0L,
+    val historyId: String = "",
+    val pace: Double = 0.0,
+    val startedAt: Long = 0L,
+    val totalDistance: Double = 0.0,
+    val totalRunningTime: Int = 0
+) : GroupNotificationResponse
+
+fun StartNotificationResponse.toStartNotification() =
+    StartNotification(
+        uid = this.uid,
+        startedAt = this.startedAt
+    )
+
+fun FinishNotificationResponse.toFinishNotification() =
+    FinishNotification(
+        uid = this.uid,
+        runningHistory = RunningHistory(
+            historyId = this.historyId,
+            startedAt = this.startedAt,
+            finishedAt = this.finishedAt,
+            totalRunningTime = this.totalRunningTime,
+            pace = this.pace,
+            totalDistance = this.totalDistance
+        )
+    )

--- a/domain/src/main/java/com/whyranoid/domain/repository/GroupRepository.kt
+++ b/domain/src/main/java/com/whyranoid/domain/repository/GroupRepository.kt
@@ -20,6 +20,9 @@ interface GroupRepository {
     // 서버에는 해당 그룹에 내 정보 넘겨주기
     suspend fun joinGroup(uid: String, groupId: String): Boolean
 
+    // 그룹 나가기 / 그룹에서 먼저 나간 후 성공하면 User 에 반영하기
+    suspend fun exitGroup(uid: String, groupId: String): Boolean
+
     // 혹은 그룹 채팅을 가져오기 + 글 작성하기
     fun getGroupNotifications(groupId: String): Flow<List<GroupNotification>>
 }


### PR DESCRIPTION
## 😎 작업 내용
- 알림들(start, finish)을 반환해주는 getGroupNotifications 추가
- GroupRepository에 exitGroup 추가(domain layer 또한 수정)
  - 관련 구현체들도 구현  

## 🧐 변경된 내용
- domain layer에 있는 GroupRepository에 exitGroup 추가

## 🥳 동작 화면
- 동작 화면 없음

## 🤯 이슈 번호
- 이슈 없음
