### PR TITLE
그룹 생성하기 페이지 구현 + 컴포즈로 커스텀 Dialog 구현

### DIFF
--- a/data/src/main/java/com/whyranoid/data/group/GroupDataSource.kt
+++ b/data/src/main/java/com/whyranoid/data/group/GroupDataSource.kt
@@ -95,7 +95,12 @@ class GroupDataSource @Inject constructor(
     }
 
     // TODO Rule 추가
-    suspend fun createGroup(groupName: String, introduce: String, uid: String): Boolean {
+    suspend fun createGroup(
+        groupName: String,
+        introduce: String,
+        rules: List<String>,
+        uid: String
+    ): Boolean {
         return suspendCancellableCoroutine { cancellableContinuation ->
             val newGroupId = UUID.randomUUID().toString()
             db.collection(GROUPS_COLLECTION)
@@ -107,7 +112,7 @@ class GroupDataSource @Inject constructor(
                         introduce = introduce,
                         leaderId = uid,
                         membersId = listOf(uid),
-                        rules = emptyList()
+                        rules = rules
                     )
                 ).addOnSuccessListener {
                     cancellableContinuation.resume(true)

--- a/data/src/main/java/com/whyranoid/data/group/GroupDataSource.kt
+++ b/data/src/main/java/com/whyranoid/data/group/GroupDataSource.kt
@@ -9,7 +9,10 @@ import com.whyranoid.data.constant.FieldId.GROUP_MEMBERS_ID
 import com.whyranoid.data.constant.FieldId.GROUP_NAME
 import com.whyranoid.data.constant.FieldId.JOINED_GROUP_LIST
 import com.whyranoid.data.constant.FieldId.RULES
+import com.whyranoid.data.model.GroupInfoResponse
 import com.whyranoid.domain.model.Rule
+import kotlinx.coroutines.suspendCancellableCoroutine
+import java.util.UUID
 import javax.inject.Inject
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
@@ -18,6 +21,7 @@ class GroupDataSource @Inject constructor(
     private val db: FirebaseFirestore
 ) {
 
+    // TODO: suspendcancellablecoroutine로 변경
     suspend fun updateGroupInfo(
         groupId: String,
         groupName: String,
@@ -45,6 +49,7 @@ class GroupDataSource @Inject constructor(
         }
     }
 
+    // TODO: suspendcancellablecoroutine로 변경
     suspend fun joinGroup(uid: String, groupId: String): Boolean {
         return suspendCoroutine<Boolean> { continuation ->
             db.collection(GROUPS_COLLECTION)
@@ -60,6 +65,7 @@ class GroupDataSource @Inject constructor(
         }
     }
 
+    // TODO: suspendcancellablecoroutine로 변경
     suspend fun exitGroup(uid: String, groupId: String): Boolean {
         return suspendCoroutine { continuation ->
             db.collection(GROUPS_COLLECTION)
@@ -84,6 +90,29 @@ class GroupDataSource @Inject constructor(
                         }
                 }.addOnFailureListener {
                     continuation.resume(false)
+                }
+        }
+    }
+
+    // TODO Rule 추가
+    suspend fun createGroup(groupName: String, introduce: String, uid: String): Boolean {
+        return suspendCancellableCoroutine { cancellableContinuation ->
+            val newGroupId = UUID.randomUUID().toString()
+            db.collection(GROUPS_COLLECTION)
+                .document(newGroupId)
+                .set(
+                    GroupInfoResponse(
+                        groupId = newGroupId,
+                        groupName = groupName,
+                        introduce = introduce,
+                        leaderId = uid,
+                        membersId = emptyList(),
+                        rules = emptyList()
+                    )
+                ).addOnSuccessListener {
+                    cancellableContinuation.resume(true)
+                }.addOnFailureListener {
+                    cancellableContinuation.resume(false)
                 }
         }
     }

--- a/data/src/main/java/com/whyranoid/data/group/GroupDataSource.kt
+++ b/data/src/main/java/com/whyranoid/data/group/GroupDataSource.kt
@@ -106,7 +106,7 @@ class GroupDataSource @Inject constructor(
                         groupName = groupName,
                         introduce = introduce,
                         leaderId = uid,
-                        membersId = emptyList(),
+                        membersId = listOf(uid),
                         rules = emptyList()
                     )
                 ).addOnSuccessListener {

--- a/data/src/main/java/com/whyranoid/data/group/GroupRepositoryImpl.kt
+++ b/data/src/main/java/com/whyranoid/data/group/GroupRepositoryImpl.kt
@@ -46,7 +46,7 @@ class GroupRepositoryImpl @Inject constructor(
         groupNotificationDataSource.notifyRunningStart(uid, groupIdList)
     }
 
-    override suspend fun createGroup(groupName: String, introduce: String, uid: String): Boolean {
-        return groupDataSource.createGroup(groupName, introduce, uid)
+    override suspend fun createGroup(groupName: String, introduce: String, rules: List<String>, uid: String): Boolean {
+        return groupDataSource.createGroup(groupName, introduce, rules, uid)
     }
 }

--- a/data/src/main/java/com/whyranoid/data/group/GroupRepositoryImpl.kt
+++ b/data/src/main/java/com/whyranoid/data/group/GroupRepositoryImpl.kt
@@ -45,4 +45,8 @@ class GroupRepositoryImpl @Inject constructor(
     override suspend fun notifyRunningStart(uid: String, groupIdList: List<String>) {
         groupNotificationDataSource.notifyRunningStart(uid, groupIdList)
     }
+
+    override suspend fun createGroup(groupName: String, introduce: String, uid: String): Boolean {
+        return groupDataSource.createGroup(groupName, introduce, uid)
+    }
 }

--- a/domain/src/main/java/com/whyranoid/domain/repository/GroupRepository.kt
+++ b/domain/src/main/java/com/whyranoid/domain/repository/GroupRepository.kt
@@ -29,4 +29,7 @@ interface GroupRepository {
     fun getGroupNotifications(groupId: String): Flow<List<GroupNotification>>
 
     suspend fun notifyRunningStart(uid: String, groupIdList: List<String>)
+
+    // 그룹 생성하기
+    suspend fun createGroup(groupName: String, introduce: String, uid: String): Boolean
 }

--- a/domain/src/main/java/com/whyranoid/domain/repository/GroupRepository.kt
+++ b/domain/src/main/java/com/whyranoid/domain/repository/GroupRepository.kt
@@ -31,5 +31,5 @@ interface GroupRepository {
     suspend fun notifyRunningStart(uid: String, groupIdList: List<String>)
 
     // 그룹 생성하기
-    suspend fun createGroup(groupName: String, introduce: String, uid: String): Boolean
+    suspend fun createGroup(groupName: String, introduce: String, rules: List<String>, uid: String): Boolean
 }

--- a/domain/src/main/java/com/whyranoid/domain/usecase/CreateGroupUseCase.kt
+++ b/domain/src/main/java/com/whyranoid/domain/usecase/CreateGroupUseCase.kt
@@ -7,7 +7,7 @@ class CreateGroupUseCase @Inject constructor(
     private val groupRepository: GroupRepository
 ) {
     // TODO AccountRepository에서 uid를 가져와야함.
-    suspend operator fun invoke(groupName: String, introduce: String, uid: String): Boolean {
-        return groupRepository.createGroup(groupName, introduce, uid)
+    suspend operator fun invoke(groupName: String, introduce: String): Boolean {
+        return groupRepository.createGroup(groupName, introduce, uid = "hsjeon")
     }
 }

--- a/domain/src/main/java/com/whyranoid/domain/usecase/CreateGroupUseCase.kt
+++ b/domain/src/main/java/com/whyranoid/domain/usecase/CreateGroupUseCase.kt
@@ -7,7 +7,7 @@ class CreateGroupUseCase @Inject constructor(
     private val groupRepository: GroupRepository
 ) {
     // TODO AccountRepository에서 uid를 가져와야함.
-    suspend operator fun invoke(groupName: String, introduce: String): Boolean {
-        return groupRepository.createGroup(groupName, introduce, uid = "hsjeon")
+    suspend operator fun invoke(groupName: String, introduce: String, rules: List<String>): Boolean {
+        return groupRepository.createGroup(groupName, introduce, rules = rules, uid = "hsjeon")
     }
 }

--- a/domain/src/main/java/com/whyranoid/domain/usecase/CreateGroupUseCase.kt
+++ b/domain/src/main/java/com/whyranoid/domain/usecase/CreateGroupUseCase.kt
@@ -1,0 +1,13 @@
+package com.whyranoid.domain.usecase
+
+import com.whyranoid.domain.repository.GroupRepository
+import javax.inject.Inject
+
+class CreateGroupUseCase @Inject constructor(
+    private val groupRepository: GroupRepository
+) {
+    // TODO AccountRepository에서 uid를 가져와야함.
+    suspend operator fun invoke(groupName: String, introduce: String, uid: String): Boolean {
+        return groupRepository.createGroup(groupName, introduce, uid)
+    }
+}

--- a/presentation/build.gradle
+++ b/presentation/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id "org.jetbrains.kotlin.android"
     id "kotlin-kapt"
     id "dagger.hilt.android.plugin"
+    id "androidx.navigation.safeargs.kotlin"
 }
 
 android {

--- a/presentation/build.gradle
+++ b/presentation/build.gradle
@@ -34,6 +34,10 @@ android {
     }
     buildFeatures {
         dataBinding true
+        compose true
+    }
+    composeOptions {
+        kotlinCompilerExtensionVersion = "1.3.2"
     }
 }
 
@@ -78,7 +82,16 @@ dependencies {
 
     // shimmer
     implementation "com.facebook.shimmer:shimmer:$shimmerVersion"
-    
+
     // Calendar Library
     implementation "com.github.kizitonwose:CalendarView:$calendarVersion"
+
+    // composeBom
+    def composeBom = platform("androidx.compose:compose-bom:2022.10.00")
+    implementation composeBom
+    androidTestImplementation composeBom
+
+    // or Material Design 2
+    implementation 'androidx.compose.material:material'
+
 }

--- a/presentation/src/main/java/com/whyranoid/presentation/community/CommunityFragment.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/community/CommunityFragment.kt
@@ -54,7 +54,7 @@ internal class CommunityFragment :
     private fun setOnMenuClickListener() {
         binding.topAppBar.setOnMenuItemClickListener { menuItem ->
             when (menuItem.itemId) {
-                R.id.create_group -> {
+                R.id.go_to_create_group -> {
                     val action =
                         CommunityFragmentDirections.actionCommunityFragmentToCreateGroupFragment()
                     findNavController().navigate(action)

--- a/presentation/src/main/java/com/whyranoid/presentation/community/CommunityFragment.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/community/CommunityFragment.kt
@@ -2,7 +2,10 @@ package com.whyranoid.presentation.community
 
 import android.os.Bundle
 import android.view.View
+import androidx.navigation.fragment.findNavController
 import androidx.viewpager2.adapter.FragmentStateAdapter
+import com.google.android.material.tabs.TabLayout
+import com.google.android.material.tabs.TabLayout.OnTabSelectedListener
 import com.google.android.material.tabs.TabLayoutMediator
 import com.whyranoid.presentation.R
 import com.whyranoid.presentation.base.BaseFragment
@@ -20,8 +23,47 @@ internal class CommunityFragment :
 
     private fun setTabLayout(adapter: FragmentStateAdapter) {
         binding.viewPager.adapter = adapter
+        setOnMenuClickListener()
+        binding.tabLayout.addOnTabSelectedListener(object : OnTabSelectedListener {
+            // TODO 게시글, 내가 쓴 글 추가 필요
+            override fun onTabSelected(tab: TabLayout.Tab?) {
+                when (tab?.position) {
+                    CommunityCategory.MY_GROUP.ordinal -> {
+                        binding.topAppBar.inflateMenu(R.menu.my_group_menu)
+                    }
+                }
+            }
+
+            // TODO 게시글, 내가 쓴 글 추가 필요
+            override fun onTabUnselected(tab: TabLayout.Tab?) {
+                when (tab?.position) {
+                    CommunityCategory.MY_GROUP.ordinal -> {
+                        binding.topAppBar.menu.clear()
+                    }
+                }
+            }
+
+            override fun onTabReselected(tab: TabLayout.Tab?) {
+            }
+        })
         TabLayoutMediator(binding.tabLayout, binding.viewPager) { tab, position ->
             tab.text = getString(CommunityCategory.values()[position].stringId)
         }.attach()
+    }
+
+    private fun setOnMenuClickListener() {
+        binding.topAppBar.setOnMenuItemClickListener { menuItem ->
+            when (menuItem.itemId) {
+                R.id.create_group -> {
+                    val action =
+                        CommunityFragmentDirections.actionCommunityFragmentToCreateGroupFragment()
+                    findNavController().navigate(action)
+                    true
+                }
+                else -> {
+                    false
+                }
+            }
+        }
     }
 }

--- a/presentation/src/main/java/com/whyranoid/presentation/community/CommunityItemFragment.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/community/CommunityItemFragment.kt
@@ -2,7 +2,12 @@ package com.whyranoid.presentation.community
 
 import android.os.Build
 import android.os.Bundle
+import android.view.Menu
+import android.view.MenuInflater
+import android.view.MenuItem
 import android.view.View
+import androidx.core.view.MenuHost
+import androidx.core.view.MenuProvider
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
@@ -44,6 +49,7 @@ internal class CommunityItemFragment :
             }
             CommunityCategory.MY_GROUP -> {
                 setMyGroupAdapter()
+                setupMenu()
             }
             CommunityCategory.MY_POST -> {
                 // TODO: Adapter 설정
@@ -90,6 +96,27 @@ internal class CommunityItemFragment :
                 isVisible = false
             }
         }
+    }
+
+    private fun setupMenu() {
+        (requireActivity() as MenuHost).addMenuProvider(object : MenuProvider {
+            override fun onPrepareMenu(menu: Menu) {
+                super.onPrepareMenu(menu)
+            }
+
+            override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
+                menuInflater.inflate(R.menu.my_group_menu, menu)
+            }
+
+            override fun onMenuItemSelected(menuItem: MenuItem): Boolean {
+                when (menuItem.itemId) {
+                    R.id.create_group -> {
+                        Snackbar.make(binding.root, "생성하기", Snackbar.LENGTH_SHORT).show()
+                    }
+                }
+                return true
+            }
+        })
     }
 
     companion object {

--- a/presentation/src/main/java/com/whyranoid/presentation/community/CommunityItemFragment.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/community/CommunityItemFragment.kt
@@ -2,12 +2,7 @@ package com.whyranoid.presentation.community
 
 import android.os.Build
 import android.os.Bundle
-import android.view.Menu
-import android.view.MenuInflater
-import android.view.MenuItem
 import android.view.View
-import androidx.core.view.MenuHost
-import androidx.core.view.MenuProvider
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
@@ -49,7 +44,6 @@ internal class CommunityItemFragment :
             }
             CommunityCategory.MY_GROUP -> {
                 setMyGroupAdapter()
-                setupMenu()
             }
             CommunityCategory.MY_POST -> {
                 // TODO: Adapter 설정
@@ -96,27 +90,6 @@ internal class CommunityItemFragment :
                 isVisible = false
             }
         }
-    }
-
-    private fun setupMenu() {
-        (requireActivity() as MenuHost).addMenuProvider(object : MenuProvider {
-            override fun onPrepareMenu(menu: Menu) {
-                super.onPrepareMenu(menu)
-            }
-
-            override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
-                menuInflater.inflate(R.menu.my_group_menu, menu)
-            }
-
-            override fun onMenuItemSelected(menuItem: MenuItem): Boolean {
-                when (menuItem.itemId) {
-                    R.id.create_group -> {
-                        Snackbar.make(binding.root, "생성하기", Snackbar.LENGTH_SHORT).show()
-                    }
-                }
-                return true
-            }
-        })
     }
 
     companion object {

--- a/presentation/src/main/java/com/whyranoid/presentation/community/group/CreateGroupFragment.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/community/group/CreateGroupFragment.kt
@@ -25,7 +25,6 @@ internal class CreateGroupFragment :
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        binding.lifecycleOwner = viewLifecycleOwner
         binding.viewModel = viewModel
 
         setupMenu()
@@ -86,7 +85,25 @@ internal class CreateGroupFragment :
     }
 
     private fun setupMenu() {
-        binding.topAppBar.inflateMenu(R.menu.create_group_menu)
+        with(binding.topAppBar) {
+            inflateMenu(R.menu.create_group_menu)
+
+            setOnMenuItemClickListener { menuItem ->
+                when (menuItem.itemId) {
+                    R.id.create_group_button -> {
+                        viewModel.emitEvent(Event.CreateGroupButtonClick())
+                        true
+                    }
+                    R.id.warning_about_create_group_button -> {
+                        viewModel.emitEvent(Event.WarningButtonClick)
+                        true
+                    }
+                    else -> {
+                        false
+                    }
+                }
+            }
+        }
 
         repeatWhenUiStarted {
             viewModel.isButtonEnable.collect { isEnable ->
@@ -96,22 +113,6 @@ internal class CreateGroupFragment :
                 } else {
                     binding.topAppBar.menu.setGroupVisible(R.id.ready_to_create, false)
                     binding.topAppBar.menu.setGroupVisible(R.id.not_ready_to_create, true)
-                }
-            }
-        }
-
-        binding.topAppBar.setOnMenuItemClickListener { menuItem ->
-            when (menuItem.itemId) {
-                R.id.create_group_button -> {
-                    viewModel.emitEvent(Event.CreateGroupButtonClick())
-                    true
-                }
-                R.id.warning_about_create_group_button -> {
-                    viewModel.emitEvent(Event.WarningButtonClick)
-                    true
-                }
-                else -> {
-                    false
                 }
             }
         }

--- a/presentation/src/main/java/com/whyranoid/presentation/community/group/CreateGroupFragment.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/community/group/CreateGroupFragment.kt
@@ -1,0 +1,20 @@
+package com.whyranoid.presentation.community.group
+
+import android.os.Bundle
+import android.view.View
+import androidx.fragment.app.viewModels
+import com.whyranoid.presentation.R
+import com.whyranoid.presentation.base.BaseFragment
+import com.whyranoid.presentation.databinding.FragmentCreateGroupBinding
+
+internal class CreateGroupFragment :
+    BaseFragment<FragmentCreateGroupBinding>(R.layout.fragment_create_group) {
+
+    private val viewModel: CreateGroupViewModel by viewModels()
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        binding.lifecycleOwner = viewLifecycleOwner
+        binding.viewModel = viewModel
+    }
+}

--- a/presentation/src/main/java/com/whyranoid/presentation/community/group/CreateGroupFragment.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/community/group/CreateGroupFragment.kt
@@ -2,11 +2,16 @@ package com.whyranoid.presentation.community.group
 
 import android.os.Bundle
 import android.view.View
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.google.android.material.snackbar.Snackbar
 import com.whyranoid.presentation.R
 import com.whyranoid.presentation.base.BaseFragment
+import com.whyranoid.presentation.compose.RulePicker
 import com.whyranoid.presentation.databinding.FragmentCreateGroupBinding
 import com.whyranoid.presentation.util.repeatWhenUiStarted
 import dagger.hilt.android.AndroidEntryPoint
@@ -28,6 +33,12 @@ internal class CreateGroupFragment :
         repeatWhenUiStarted {
             viewModel.eventFlow.collect { event ->
                 handleEvent(event)
+            }
+        }
+
+        repeatWhenUiStarted {
+            viewModel.rules.collect {
+                println("테스트 $it")
             }
         }
     }
@@ -56,6 +67,20 @@ internal class CreateGroupFragment :
                     getString(R.string.text_warning_create_group),
                     Snackbar.LENGTH_SHORT
                 ).show()
+            }
+            is Event.AddRuleButtonClick -> {
+                binding.composeView.apply {
+                    setViewCompositionStrategy(
+                        ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed
+                    )
+                    viewModel.onOpenDialogClicked()
+                    setContent {
+                        val showDialogState: Boolean by viewModel.showDialog.collectAsState()
+                        MaterialTheme {
+                            RulePicker(showDialogState, viewModel)
+                        }
+                    }
+                }
             }
         }
     }

--- a/presentation/src/main/java/com/whyranoid/presentation/community/group/CreateGroupFragment.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/community/group/CreateGroupFragment.kt
@@ -3,10 +3,15 @@ package com.whyranoid.presentation.community.group
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
+import com.google.android.material.snackbar.Snackbar
 import com.whyranoid.presentation.R
 import com.whyranoid.presentation.base.BaseFragment
 import com.whyranoid.presentation.databinding.FragmentCreateGroupBinding
+import com.whyranoid.presentation.util.repeatWhenUiStarted
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 internal class CreateGroupFragment :
     BaseFragment<FragmentCreateGroupBinding>(R.layout.fragment_create_group) {
 
@@ -14,7 +19,68 @@ internal class CreateGroupFragment :
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
         binding.lifecycleOwner = viewLifecycleOwner
         binding.viewModel = viewModel
+
+        setupMenu()
+
+        repeatWhenUiStarted {
+            viewModel.eventFlow.collect { event ->
+                handleEvent(event)
+            }
+        }
+    }
+
+    private fun handleEvent(event: Event) {
+        when (event) {
+            is Event.CreateGroupButtonClick -> {
+                Snackbar.make(
+                    binding.root,
+                    getString(R.string.text_complete_create_group),
+                    Snackbar.LENGTH_SHORT
+                ).show()
+                findNavController().popBackStack()
+            }
+            is Event.WarningButtonClick -> {
+                Snackbar.make(
+                    binding.root,
+                    getString(R.string.text_warning_create_group),
+                    Snackbar.LENGTH_SHORT
+                ).show()
+            }
+        }
+    }
+
+    private fun setupMenu() {
+        binding.topAppBar.inflateMenu(R.menu.create_group_menu)
+
+        repeatWhenUiStarted {
+            viewModel.isButtonEnable.collect { isEnable ->
+                if (isEnable) {
+                    binding.topAppBar.menu.setGroupVisible(R.id.ready_to_create, true)
+                    binding.topAppBar.menu.setGroupVisible(R.id.not_ready_to_create, false)
+                } else {
+                    binding.topAppBar.menu.setGroupVisible(R.id.ready_to_create, false)
+                    binding.topAppBar.menu.setGroupVisible(R.id.not_ready_to_create, true)
+                }
+            }
+        }
+
+        binding.topAppBar.setOnMenuItemClickListener { menuItem ->
+            when (menuItem.itemId) {
+                R.id.create_group_button -> {
+                    viewModel.emitEvent(Event.CreateGroupButtonClick())
+                    true
+                }
+                R.id.warning_about_create_group_button -> {
+                    viewModel.emitEvent(Event.WarningButtonClick)
+                    true
+                }
+                else -> {
+                    false
+                }
+            }
+        }
     }
 }

--- a/presentation/src/main/java/com/whyranoid/presentation/community/group/CreateGroupFragment.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/community/group/CreateGroupFragment.kt
@@ -35,12 +35,20 @@ internal class CreateGroupFragment :
     private fun handleEvent(event: Event) {
         when (event) {
             is Event.CreateGroupButtonClick -> {
-                Snackbar.make(
-                    binding.root,
-                    getString(R.string.text_complete_create_group),
-                    Snackbar.LENGTH_SHORT
-                ).show()
-                findNavController().popBackStack()
+                if (event.isSuccess) {
+                    Snackbar.make(
+                        binding.root,
+                        getString(R.string.text_create_group_success),
+                        Snackbar.LENGTH_SHORT
+                    ).show()
+                    findNavController().popBackStack()
+                } else {
+                    Snackbar.make(
+                        binding.root,
+                        getString(R.string.text_create_group_fail),
+                        Snackbar.LENGTH_SHORT
+                    ).show()
+                }
             }
             is Event.WarningButtonClick -> {
                 Snackbar.make(

--- a/presentation/src/main/java/com/whyranoid/presentation/community/group/CreateGroupViewModel.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/community/group/CreateGroupViewModel.kt
@@ -49,7 +49,7 @@ class CreateGroupViewModel @Inject constructor(
                     if (isCreateGroupSuccess) {
                         _eventFlow.emit(event)
                     } else {
-                        _eventFlow.emit(event.copy(isCompleted = false))
+                        _eventFlow.emit(event.copy(isSuccess = false))
                     }
                 }
                 is Event.WarningButtonClick -> {

--- a/presentation/src/main/java/com/whyranoid/presentation/community/group/CreateGroupViewModel.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/community/group/CreateGroupViewModel.kt
@@ -1,0 +1,24 @@
+package com.whyranoid.presentation.community.group
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+
+class CreateGroupViewModel : ViewModel() {
+
+    val groupName = MutableStateFlow<String?>(null)
+    val groupIntroduce = MutableStateFlow<String?>(null)
+
+    val isButtonEnable: StateFlow<Boolean>
+        get() = groupName.combine(groupIntroduce) { name, introduce ->
+            name?.isNotEmpty() ?: false && introduce?.isNotEmpty() ?: false
+        }.stateIn(
+            scope = viewModelScope,
+            initialValue = false,
+            started = SharingStarted.WhileSubscribed(5000)
+        )
+}

--- a/presentation/src/main/java/com/whyranoid/presentation/community/group/CreateGroupViewModel.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/community/group/CreateGroupViewModel.kt
@@ -2,23 +2,60 @@ package com.whyranoid.presentation.community.group
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.whyranoid.domain.usecase.CreateGroupUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import javax.inject.Inject
 
-class CreateGroupViewModel : ViewModel() {
+@HiltViewModel
+class CreateGroupViewModel @Inject constructor(
+    private val createGroupUseCase: CreateGroupUseCase
+) : ViewModel() {
 
     val groupName = MutableStateFlow<String?>(null)
     val groupIntroduce = MutableStateFlow<String?>(null)
 
+    private val _eventFlow = MutableSharedFlow<Event>()
+    val eventFlow = _eventFlow.asSharedFlow()
+
     val isButtonEnable: StateFlow<Boolean>
         get() = groupName.combine(groupIntroduce) { name, introduce ->
-            name?.isNotEmpty() ?: false && introduce?.isNotEmpty() ?: false
+            name?.trim()?.isNotEmpty() ?: false && introduce?.trim()?.isNotEmpty() ?: false
         }.stateIn(
             scope = viewModelScope,
             initialValue = false,
             started = SharingStarted.WhileSubscribed(5000)
         )
+
+    // TODO 그룹명 중복확인 로직
+    fun onButtonClicked() {
+    }
+
+    fun emitEvent(event: Event) {
+        viewModelScope.launch {
+            when (event) {
+                is Event.CreateGroupButtonClick -> {
+                    val isCreateGroupSuccess = createGroupUseCase(
+                        groupName.value ?: "",
+                        groupIntroduce.value ?: ""
+                    )
+                    if (isCreateGroupSuccess) {
+                        _eventFlow.emit(event)
+                    } else {
+                        _eventFlow.emit(event.copy(isCompleted = false))
+                    }
+                }
+                is Event.WarningButtonClick -> {
+                    _eventFlow.emit(event)
+                }
+            }
+        }
+    }
 }

--- a/presentation/src/main/java/com/whyranoid/presentation/community/group/Event.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/community/group/Event.kt
@@ -3,4 +3,5 @@ package com.whyranoid.presentation.community.group
 sealed class Event {
     data class CreateGroupButtonClick(val isSuccess: Boolean = true) : Event()
     object WarningButtonClick : Event()
+    object AddRuleButtonClick : Event()
 }

--- a/presentation/src/main/java/com/whyranoid/presentation/community/group/Event.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/community/group/Event.kt
@@ -1,6 +1,6 @@
 package com.whyranoid.presentation.community.group
 
 sealed class Event {
-    data class CreateGroupButtonClick(val isCompleted: Boolean = true) : Event()
+    data class CreateGroupButtonClick(val isSuccess: Boolean = true) : Event()
     object WarningButtonClick : Event()
 }

--- a/presentation/src/main/java/com/whyranoid/presentation/community/group/Event.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/community/group/Event.kt
@@ -1,0 +1,6 @@
+package com.whyranoid.presentation.community.group
+
+sealed class Event {
+    data class CreateGroupButtonClick(val isCompleted: Boolean = true) : Event()
+    object WarningButtonClick : Event()
+}

--- a/presentation/src/main/java/com/whyranoid/presentation/compose/DropDownMenu.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/compose/DropDownMenu.kt
@@ -1,0 +1,106 @@
+package com.whyranoid.presentation.compose
+
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.material.Button
+import androidx.compose.material.DropdownMenu
+import androidx.compose.material.DropdownMenuItem
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+
+@Composable
+fun DateDropDownMenu(
+    selectedDate: String,
+    onDateSelected: (String) -> Unit
+) {
+    val dateList = "월 화 수 목 금 토 일".split(" ").toList()
+    var isDropDownMenuExpanded by remember { mutableStateOf(false) }
+    Button(
+        onClick = { isDropDownMenuExpanded = true }
+    ) {
+        Text(text = selectedDate)
+    }
+
+    DropdownMenu(
+        modifier = Modifier
+            .wrapContentSize(),
+        expanded = isDropDownMenuExpanded,
+        onDismissRequest = { isDropDownMenuExpanded = false }
+    ) {
+        dateList.forEach { date ->
+            DropdownMenuItem(onClick = {
+                onDateSelected(date)
+                isDropDownMenuExpanded = false
+            }) {
+                Text(text = date)
+            }
+        }
+    }
+}
+
+@Composable
+fun HourDropDownMenu(
+    selectedHour: String,
+    onHourSelected: (String) -> Unit
+) {
+    val hourList =
+        "0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23".split(" ").toList()
+    var isDropDownMenuExpanded by remember { mutableStateOf(false) }
+    Button(
+        onClick = { isDropDownMenuExpanded = true }
+    ) {
+        Text(text = selectedHour)
+    }
+
+    DropdownMenu(
+        modifier = Modifier
+            .wrapContentSize(),
+        expanded = isDropDownMenuExpanded,
+        onDismissRequest = { isDropDownMenuExpanded = false }
+    ) {
+        hourList.forEach { hour ->
+            DropdownMenuItem(onClick = {
+                onHourSelected(hour)
+                isDropDownMenuExpanded = false
+            }) {
+                Text(text = hour)
+            }
+        }
+    }
+}
+
+@Composable
+fun MinuteDropDownMenu(
+    selectedMinute: String,
+    onMinuteSelected: (String) -> Unit
+) {
+    val minuteList =
+        "0 5 10 15 20 25 30 35 40 45 50 55 60".split(" ").toList()
+    var isDropDownMenuExpanded by remember { mutableStateOf(false) }
+
+    Button(
+        onClick = { isDropDownMenuExpanded = true }
+    ) {
+        Text(text = selectedMinute)
+    }
+
+    DropdownMenu(
+        modifier = Modifier
+            .wrapContentSize(),
+        expanded = isDropDownMenuExpanded,
+        onDismissRequest = { isDropDownMenuExpanded = false }
+    ) {
+        minuteList.forEach { minute ->
+            DropdownMenuItem(onClick = {
+                onMinuteSelected(minute)
+                isDropDownMenuExpanded = false
+            }) {
+                Text(text = minute)
+            }
+        }
+    }
+}

--- a/presentation/src/main/java/com/whyranoid/presentation/compose/RulePicker.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/compose/RulePicker.kt
@@ -1,0 +1,75 @@
+package com.whyranoid.presentation.compose
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.AlertDialog
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.whyranoid.presentation.community.group.CreateGroupViewModel
+
+@Composable
+fun RulePicker(
+    declarationDialogState: Boolean,
+    viewModel: CreateGroupViewModel
+) {
+    var selectedDate by remember { mutableStateOf("요일") }
+    var selectedHour by remember { mutableStateOf("시간") }
+    var selectedMinute by remember { mutableStateOf("분") }
+    if (declarationDialogState) {
+        AlertDialog(
+            onDismissRequest = {
+                viewModel.onDialogDismiss()
+            },
+            title = {
+                Text(text = "요일 및 시간을 골라주세요!!")
+            },
+            text = {
+                Column {
+                    DateDropDownMenu(selectedDate) { date ->
+                        selectedDate = date
+                    }
+                    Spacer(modifier = Modifier.padding(bottom = 10.dp))
+                    HourDropDownMenu(selectedHour) { hour ->
+                        selectedHour = hour
+                    }
+                    Spacer(modifier = Modifier.padding(bottom = 10.dp))
+                    MinuteDropDownMenu(selectedMinute) { minute ->
+                        selectedMinute = minute
+                    }
+                }
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        viewModel.onDialogConfirm(selectedDate, selectedHour, selectedMinute)
+                        selectedDate = "요일"
+                        selectedHour = "시간"
+                        selectedMinute = "분"
+                    }
+                ) {
+                    Text("확인")
+                }
+            },
+            dismissButton = {
+                TextButton(
+                    onClick = {
+                        viewModel.onDialogDismiss()
+                        selectedDate = "요일"
+                        selectedHour = "시간"
+                        selectedMinute = "분"
+                    }
+                ) {
+                    Text("취소")
+                }
+            }
+        )
+    }
+}

--- a/presentation/src/main/res/drawable/done_outline_icon.xml
+++ b/presentation/src/main/res/drawable/done_outline_icon.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#ACD182"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M19.77,5.03l1.4,1.4L8.43,19.17l-5.6,-5.6 1.4,-1.4 4.2,4.2L19.77,5.03m0,-2.83L8.43,13.54l-4.2,-4.2L0,13.57 8.43,22 24,6.43 19.77,2.2z"/>
+</vector>

--- a/presentation/src/main/res/drawable/done_solid_icon.xml
+++ b/presentation/src/main/res/drawable/done_solid_icon.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#ACD182"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M9,16.2L4.8,12l-1.4,1.4L9,19 21,7l-1.4,-1.4L9,16.2z"/>
+</vector>

--- a/presentation/src/main/res/drawable/plus_button.xml
+++ b/presentation/src/main/res/drawable/plus_button.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#ACD182"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M19,13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/>
+</vector>

--- a/presentation/src/main/res/layout/fragment_create_group.xml
+++ b/presentation/src/main/res/layout/fragment_create_group.xml
@@ -60,23 +60,36 @@
             android:layout_height="wrap_content"
             android:layout_margin="16dp"
             android:enabled="@{viewModel.isButtonEnable()}"
-            android:onClick="@{() -> viewModel.onButtonClicked()}"
+            android:onClick="@{() -> viewModel.onDuplicateCheckButtonClicked()}"
             android:text="@string/text_duplicate_check"
             app:layout_constraintBottom_toTopOf="@id/time_and_date_picker"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toBottomOf="@id/app_bar" />
 
-        <!-- TODO 요일, 시간 피커 추가 -->
         <TextView
             android:id="@+id/time_and_date_picker"
+            style="@style/MoGakRunText.Bold.Medium"
             android:layout_width="0dp"
             android:layout_height="70dp"
             android:layout_margin="16dp"
             android:background="@color/mogakrun_secondary_dark"
-            app:layout_constraintEnd_toEndOf="parent"
+            android:gravity="center_vertical"
+            android:text="@{viewModel.rules.toString()}"
+            app:layout_constraintEnd_toStartOf="@id/btn_select_rule"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/text_input_layout_group_name"
-            tools:text="피커가 들어갈 자리입니다~" />
+            tools:text="규칙들 들어갈 자리입니다~" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_select_rule"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_margin="16dp"
+            android:onClick="@{() -> viewModel.onAddRuleButtonClicked()}"
+            android:text="@string/text_select_rule"
+            app:layout_constraintBottom_toTopOf="@id/text_input_layout_group_introduce"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/text_input_layout_group_name" />
 
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/text_input_layout_group_introduce"
@@ -105,6 +118,15 @@
                 android:textColor="@color/mogakrun_on_secondary" />
 
         </com.google.android.material.textfield.TextInputLayout>
+
+        <androidx.compose.ui.platform.ComposeView
+            android:id="@+id/compose_view"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
 
 
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/presentation/src/main/res/layout/fragment_create_group.xml
+++ b/presentation/src/main/res/layout/fragment_create_group.xml
@@ -60,6 +60,7 @@
             android:layout_height="wrap_content"
             android:layout_margin="16dp"
             android:enabled="@{viewModel.isButtonEnable()}"
+            android:onClick="@{() -> viewModel.onButtonClicked()}"
             android:text="@string/text_duplicate_check"
             app:layout_constraintBottom_toTopOf="@id/time_and_date_picker"
             app:layout_constraintEnd_toEndOf="parent"
@@ -95,12 +96,12 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:layout_weight="1"
-                android:text="@={viewModel.groupIntroduce}"
                 android:background="@color/mogakrun_secondary"
                 android:gravity="top|start"
                 android:hint="@string/text_group_introduce"
                 android:maxLength="200"
                 android:minLines="2"
+                android:text="@={viewModel.groupIntroduce}"
                 android:textColor="@color/mogakrun_on_secondary" />
 
         </com.google.android.material.textfield.TextInputLayout>

--- a/presentation/src/main/res/layout/fragment_create_group.xml
+++ b/presentation/src/main/res/layout/fragment_create_group.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="viewModel"
+            type="com.whyranoid.presentation.community.group.CreateGroupViewModel" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".community.group.CreateGroupFragment">
+
+        <com.google.android.material.appbar.AppBarLayout
+            android:id="@+id/app_bar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <com.google.android.material.appbar.MaterialToolbar
+                android:id="@+id/top_app_bar"
+                style="@style/Widget.MaterialComponents.Toolbar.Primary"
+                android:layout_width="match_parent"
+                android:layout_height="?attr/actionBarSize"
+                app:title="@string/text_create_group" />
+
+        </com.google.android.material.appbar.AppBarLayout>
+
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/text_input_layout_group_name"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_margin="16dp"
+            android:background="@color/mogakrun_primary"
+            app:counterEnabled="true"
+            app:layout_constraintEnd_toStartOf="@id/btn_duplicate_check"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/app_bar">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/et_group_name"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="@color/mogakrun_secondary"
+                android:hint="@string/text_group_name"
+                android:maxLength="20"
+                android:text="@={viewModel.groupName}"
+                android:textColor="@color/mogakrun_on_secondary" />
+
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_duplicate_check"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_margin="16dp"
+            android:enabled="@{viewModel.isButtonEnable()}"
+            android:text="@string/text_duplicate_check"
+            app:layout_constraintBottom_toTopOf="@id/time_and_date_picker"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/app_bar" />
+
+        <!-- TODO 요일, 시간 피커 추가 -->
+        <TextView
+            android:id="@+id/time_and_date_picker"
+            android:layout_width="0dp"
+            android:layout_height="70dp"
+            android:layout_margin="16dp"
+            android:background="@color/mogakrun_secondary_dark"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/text_input_layout_group_name"
+            tools:text="피커가 들어갈 자리입니다~" />
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/text_input_layout_group_introduce"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:layout_margin="16dp"
+            android:background="@color/mogakrun_primary"
+            android:gravity="top|start"
+            app:counterEnabled="true"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/time_and_date_picker">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/text_group_introduce"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:text="@={viewModel.groupIntroduce}"
+                android:background="@color/mogakrun_secondary"
+                android:gravity="top|start"
+                android:hint="@string/text_group_introduce"
+                android:maxLength="200"
+                android:minLines="2"
+                android:textColor="@color/mogakrun_on_secondary" />
+
+        </com.google.android.material.textfield.TextInputLayout>
+
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/presentation/src/main/res/menu/create_group_menu.xml
+++ b/presentation/src/main/res/menu/create_group_menu.xml
@@ -2,7 +2,6 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
-
     <group
         android:id="@+id/not_ready_to_create"
         android:visible="false">

--- a/presentation/src/main/res/menu/create_group_menu.xml
+++ b/presentation/src/main/res/menu/create_group_menu.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+
+    <group
+        android:id="@+id/not_ready_to_create"
+        android:visible="false">
+        <item
+            android:id="@+id/warning_about_create_group_button"
+            android:enabled="true"
+            android:icon="@drawable/done_outline_icon"
+            android:title="@string/text_create_group"
+            app:showAsAction="ifRoom"/>
+    </group>
+
+    <group
+        android:id="@+id/ready_to_create"
+        android:visible="false">
+        <item
+            android:id="@+id/create_group_button"
+            android:enabled="true"
+            android:icon="@drawable/done_solid_icon"
+            android:title="@string/text_create_group"
+            app:showAsAction="ifRoom"/>
+    </group>
+
+</menu>

--- a/presentation/src/main/res/menu/my_group_menu.xml
+++ b/presentation/src/main/res/menu/my_group_menu.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:id="@+id/create_group"
+        android:enabled="true"
+        android:icon="@drawable/plus_button"
+        android:title="@string/text_create_group"
+        app:showAsAction="always"/>
+</menu>

--- a/presentation/src/main/res/menu/my_group_menu.xml
+++ b/presentation/src/main/res/menu/my_group_menu.xml
@@ -3,9 +3,9 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <item
-        android:id="@+id/create_group"
+        android:id="@+id/go_to_create_group"
         android:enabled="true"
         android:icon="@drawable/plus_button"
-        android:title="@string/text_create_group"
+        android:title="@string/text_go_to_create_group"
         app:showAsAction="always"/>
 </menu>

--- a/presentation/src/main/res/navigation/navigation_graph.xml
+++ b/presentation/src/main/res/navigation/navigation_graph.xml
@@ -28,5 +28,19 @@
             android:id="@+id/action_runningStartFragment_to_myRunFragment"
             app:destination="@id/myRunFragment" />
     </fragment>
+    <fragment
+        android:id="@+id/communityFragment"
+        android:name="com.whyranoid.presentation.community.CommunityFragment"
+        android:label="CommunityFragment"
+        tools:layout="@layout/fragment_community">
+        <action
+            android:id="@+id/action_communityFragment_to_createGroupFragment"
+            app:destination="@id/createGroupFragment" />
+    </fragment>
+    <fragment
+        android:id="@+id/createGroupFragment"
+        android:name="com.whyranoid.presentation.community.group.CreateGroupFragment"
+        android:label="CreateGroupFragment"
+        tools:layout="@layout/fragment_create_group"/>
 
 </navigation>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -41,5 +41,7 @@
     <string name="text_group_introduce">그룹 소개</string>
     <string name="text_duplicate_check">중복확인</string>
     <string name="text_create_group">그룹 생성하기</string>
+    <string name="text_warning_create_group">그룹명과 그룹 소개를 입력해주세요.</string>
+    <string name="text_complete_create_group">그룹이 생성되었습니다!</string>
 
 </resources>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -1,4 +1,4 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">>
 
     <string name="app_name">MoGakRun</string>
 
@@ -6,7 +6,7 @@
     <string name="bottom_navigation_menu_community">커뮤니티</string>
     <string name="bottom_navigation_menu_running">러닝</string>
     <string name="bottom_navigation_menu_my_run">마이런</string>
-    
+
     <!-- 러닝 탭 화면 -->
     <string name="runner_start_runner_unit">명</string>
     <string name="runner_start_prefix">지금,</string>
@@ -34,5 +34,11 @@
     <string name="setting_service_policy">서비스 이용약관</string>
     <string name="setting_open_source_license">오픈소스 라이센스</string>
     <string name="setting_log_out">로그아웃</string>
+
+    <!-- 그룹 생성하기 화면-->
+    <string name="text_group_name">그룹명</string>
+    <string name="text_create_group">그룹 생성하기</string>
+    <string name="text_group_introduce">그룹 소개</string>
+    <string name="text_duplicate_check">중복확인</string>
 
 </resources>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -44,5 +44,6 @@
     <string name="text_warning_create_group">그룹명과 그룹 소개를 입력해주세요.</string>
     <string name="text_create_group_success">그룹이 생성되었습니다!</string>
     <string name="text_create_group_fail">그룹 생성에 실패하였습니다.</string>
+    <string name="text_select_rule">규칙 고르기</string>
 
 </resources>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -42,6 +42,7 @@
     <string name="text_duplicate_check">중복확인</string>
     <string name="text_create_group">그룹 생성하기</string>
     <string name="text_warning_create_group">그룹명과 그룹 소개를 입력해주세요.</string>
-    <string name="text_complete_create_group">그룹이 생성되었습니다!</string>
+    <string name="text_create_group_success">그룹이 생성되었습니다!</string>
+    <string name="text_create_group_fail">그룹 생성에 실패하였습니다.</string>
 
 </resources>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -37,8 +37,9 @@
 
     <!-- 그룹 생성하기 화면-->
     <string name="text_group_name">그룹명</string>
-    <string name="text_create_group">그룹 생성하기</string>
+    <string name="text_go_to_create_group">그룹 생성하러 가기</string>
     <string name="text_group_introduce">그룹 소개</string>
     <string name="text_duplicate_check">중복확인</string>
+    <string name="text_create_group">그룹 생성하기</string>
 
 </resources>


### PR DESCRIPTION
## 😎 작업 내용
- presentation레이어에 safeArgs 플러그인 추가
- 커뮤니티 프레그먼트의 내 그룹 탭에서 그룹 생성하기로 이동하는 기능 추가
- 그룹 생성하기 프레그먼트 추가
- 그룹명, 그룹 소개를 입력해야 그룹을 생성할 수 있도록 메뉴 추가
- 컴포즈로 규칙 정하는 Dialog 구현

## 🧐 변경된 내용
- GroupRepository에 createGroup() 추가

## 🥳 동작 화면

- 내 그룹 탭에서만 메뉴가 생기는 모습
![menuinflate](https://user-images.githubusercontent.com/90144041/203540035-5932d402-6d02-4315-8510-73458ff1cef8.gif)

- 그룸명, 그룹 소개가 없으면 생성 메뉴 및 중복확인 버튼이 활성화되지 않는 모습
![createMenu](https://user-images.githubusercontent.com/90144041/203540763-fdb7b96d-1268-4fc2-8f93-9df921408ea5.gif)

- 컴포즈를 사용한 Dialog를 이용하여 규칙을 정하는 모습
![makeRules](https://user-images.githubusercontent.com/90144041/203604473-5875f02b-98dc-47f5-8ebd-8bab3b7a035d.gif)


## 🤯 이슈 번호
- #31  
