### PR TITLE
그룹 상세보기 페이지 구현

### DIFF
--- a/domain/src/main/java/com/whyranoid/domain/model/GroupInfo.kt
+++ b/domain/src/main/java/com/whyranoid/domain/model/GroupInfo.kt
@@ -1,7 +1,5 @@
 package com.whyranoid.domain.model
 
-import java.io.Serializable
-
 data class GroupInfo(
     val name: String,
     val groupId: String,
@@ -9,4 +7,4 @@ data class GroupInfo(
     val rules: List<Rule>,
     val headCount: Int,
     val leader: User
-) : Serializable
+)

--- a/domain/src/main/java/com/whyranoid/domain/model/GroupInfo.kt
+++ b/domain/src/main/java/com/whyranoid/domain/model/GroupInfo.kt
@@ -1,5 +1,7 @@
 package com.whyranoid.domain.model
 
+import java.io.Serializable
+
 data class GroupInfo(
     val name: String,
     val groupId: String,
@@ -7,4 +9,4 @@ data class GroupInfo(
     val rules: List<Rule>,
     val headCount: Int,
     val leader: User
-)
+) : Serializable

--- a/presentation/build.gradle
+++ b/presentation/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id "kotlin-kapt"
     id "dagger.hilt.android.plugin"
     id "androidx.navigation.safeargs.kotlin"
+    id "kotlin-parcelize"
 }
 
 android {

--- a/presentation/src/main/java/com/whyranoid/presentation/community/CommunityFragment.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/community/CommunityFragment.kt
@@ -68,7 +68,6 @@ internal class CommunityFragment :
     }
 
     override fun onDestroyView() {
-
         // 뷰페이저 메모리 누수 해결
         binding.viewPager.adapter = null
 

--- a/presentation/src/main/java/com/whyranoid/presentation/community/CommunityFragment.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/community/CommunityFragment.kt
@@ -66,4 +66,12 @@ internal class CommunityFragment :
             }
         }
     }
+
+    override fun onDestroyView() {
+
+        // 뷰페이저 메모리 누수 해결
+        binding.viewPager.adapter = null
+
+        super.onDestroyView()
+    }
 }

--- a/presentation/src/main/java/com/whyranoid/presentation/community/CommunityItemFragment.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/community/CommunityItemFragment.kt
@@ -10,6 +10,7 @@ import androidx.navigation.fragment.findNavController
 import com.whyranoid.presentation.R
 import com.whyranoid.presentation.base.BaseFragment
 import com.whyranoid.presentation.databinding.FragmentCommunityItemBinding
+import com.whyranoid.presentation.model.toGroupInfoUiModel
 import com.whyranoid.presentation.util.repeatWhenUiStarted
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
@@ -63,7 +64,7 @@ internal class CommunityItemFragment :
         when (event) {
             is Event.CategoryItemClick -> {
                 val action =
-                    CommunityFragmentDirections.actionCommunityFragmentToGroupDetailFragment(event.groupInfo)
+                    CommunityFragmentDirections.actionCommunityFragmentToGroupDetailFragment(event.groupInfo.toGroupInfoUiModel())
                 findNavController().navigate(action)
             }
         }

--- a/presentation/src/main/java/com/whyranoid/presentation/community/CommunityItemFragment.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/community/CommunityItemFragment.kt
@@ -6,7 +6,7 @@ import android.view.View
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
-import com.google.android.material.snackbar.Snackbar
+import androidx.navigation.fragment.findNavController
 import com.whyranoid.presentation.R
 import com.whyranoid.presentation.base.BaseFragment
 import com.whyranoid.presentation.databinding.FragmentCommunityItemBinding
@@ -62,8 +62,9 @@ internal class CommunityItemFragment :
     private fun handleEvent(event: Event) {
         when (event) {
             is Event.CategoryItemClick -> {
-                Snackbar.make(binding.root, "${event.groupInfo.name} 클릭됨", Snackbar.LENGTH_SHORT)
-                    .show()
+                val action =
+                    CommunityFragmentDirections.actionCommunityFragmentToGroupDetailFragment(event.groupInfo)
+                findNavController().navigate(action)
             }
         }
     }

--- a/presentation/src/main/java/com/whyranoid/presentation/community/group/detail/Event.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/community/group/detail/Event.kt
@@ -1,0 +1,6 @@
+package com.whyranoid.presentation.community.group.detail
+
+sealed class Event {
+    object RecruitButtonClick : Event()
+    object ExitGroupButtonClick : Event()
+}

--- a/presentation/src/main/java/com/whyranoid/presentation/community/group/detail/GroupDetailFragment.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/community/group/detail/GroupDetailFragment.kt
@@ -91,11 +91,13 @@ internal class GroupDetailFragment :
     }
 
     private fun setBindingData() {
-        binding.viewModel = viewModel
-        binding.groupInfo = groupDetailArgs.groupInfo
-        // TODO : uid를 DataStore에서 가져올 수 있도록 변경
-        // TODO : ViewModel로 옮기기
-        binding.isLeader = groupDetailArgs.groupInfo.leader.name == "soopeach"
+        with(binding) {
+            viewModel = viewModel
+            groupInfo = groupDetailArgs.groupInfo
+            // TODO : uid를 DataStore에서 가져올 수 있도록 변경
+            // TODO : ViewModel로 옮기기
+            isLeader = groupDetailArgs.groupInfo.leader.name == "soopeach"
+        }
     }
 
     // TODO : uid를 DataStore에서 가져올 수 있도록 변경

--- a/presentation/src/main/java/com/whyranoid/presentation/community/group/detail/GroupDetailFragment.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/community/group/detail/GroupDetailFragment.kt
@@ -1,0 +1,100 @@
+package com.whyranoid.presentation.community.group.detail
+
+import android.os.Bundle
+import android.view.View
+import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.navArgs
+import com.google.android.material.snackbar.Snackbar
+import com.whyranoid.presentation.R
+import com.whyranoid.presentation.base.BaseFragment
+import com.whyranoid.presentation.databinding.FragmentGroupDetailBinding
+import com.whyranoid.presentation.util.repeatWhenUiStarted
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+internal class GroupDetailFragment :
+    BaseFragment<FragmentGroupDetailBinding>(R.layout.fragment_group_detail) {
+
+    private val viewModel: GroupDetailViewModel by viewModels()
+    private val groupDetailArgs by navArgs<GroupDetailFragmentArgs>()
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        setupMenu()
+        handleEvent()
+        setBindingData()
+        setNotificationAdapter()
+    }
+
+    private fun setupMenu() {
+        with(binding.topAppBar) {
+            // TODO : uid를 DataStore에서 가져올 수 있도록 변경
+            if (groupDetailArgs.groupInfo.leader.name == "soopeach") {
+                inflateMenu(R.menu.group_detail_menu)
+            }
+
+            setOnMenuItemClickListener { menuItem ->
+                when (menuItem.itemId) {
+                    // TODO : 그룹 설정 페이지로 이동
+                    R.id.setting_group -> {
+                        Snackbar.make(
+                            binding.root,
+                            getString(R.string.text_setting_group),
+                            Snackbar.LENGTH_SHORT
+                        ).show()
+                        true
+                    }
+                    else -> {
+                        false
+                    }
+                }
+            }
+        }
+    }
+
+    private fun handleEvent() {
+        repeatWhenUiStarted {
+            viewModel.eventFlow.collect { event ->
+                when (event) {
+                    // TODO : 홍보 글 쓰러가기
+                    Event.RecruitButtonClick -> {
+                        Snackbar.make(
+                            binding.root,
+                            getString(R.string.text_recruit),
+                            Snackbar.LENGTH_SHORT
+                        ).show()
+                    }
+                    // TODO : 그룹 나가기
+                    Event.ExitGroupButtonClick -> {
+                        Snackbar.make(
+                            binding.root,
+                            getString(R.string.text_exit_group),
+                            Snackbar.LENGTH_SHORT
+                        ).show()
+                    }
+                }
+            }
+        }
+    }
+
+    private fun setBindingData() {
+        binding.viewModel = viewModel
+        binding.groupInfo = groupDetailArgs.groupInfo
+        // TODO : uid를 DataStore에서 가져올 수 있도록 변경
+        // TODO : ViewModel로 옮기기
+        binding.isLeader = groupDetailArgs.groupInfo.leader.name == "soopeach"
+    }
+
+    // TODO : uid를 DataStore에서 가져올 수 있도록 변경
+    private fun setNotificationAdapter() {
+        val notificationAdapter = GroupNotificationAdapter("hsjeon")
+
+        binding.notificationRecyclerView.adapter = notificationAdapter
+        repeatWhenUiStarted {
+            viewModel.mergedNotifications.collect { notifications ->
+                notificationAdapter.submitList(notifications)
+            }
+        }
+    }
+}

--- a/presentation/src/main/java/com/whyranoid/presentation/community/group/detail/GroupDetailFragment.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/community/group/detail/GroupDetailFragment.kt
@@ -2,6 +2,7 @@ package com.whyranoid.presentation.community.group.detail
 
 import android.os.Bundle
 import android.view.View
+import android.widget.Toast
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.navArgs
 import com.google.android.material.snackbar.Snackbar
@@ -36,13 +37,24 @@ internal class GroupDetailFragment :
 
             setOnMenuItemClickListener { menuItem ->
                 when (menuItem.itemId) {
-                    // TODO : 그룹 설정 페이지로 이동
                     R.id.setting_group -> {
-                        Snackbar.make(
-                            binding.root,
-                            getString(R.string.text_setting_group),
-                            Snackbar.LENGTH_SHORT
-                        ).show()
+                        // TODO : BottomSheetDialog Material Theme 적용
+                        val dialog = GroupSettingDialog(
+                            // TODO : 그룹 수정으로 이동
+                            onEditButtonClickListener = {
+                                Toast.makeText(context, "그룹 수정하기", Toast.LENGTH_SHORT).show()
+                            },
+                            // TODO : 그룹 삭제
+                            onDeleteButtonClickListener = {
+                                Toast.makeText(context, "그룹 삭제하기", Toast.LENGTH_SHORT).show()
+                            }
+                        )
+
+                        dialog.show(
+                            requireActivity().supportFragmentManager,
+                            GroupSettingDialog.TAG
+                        )
+
                         true
                     }
                     else -> {

--- a/presentation/src/main/java/com/whyranoid/presentation/community/group/detail/GroupDetailViewModel.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/community/group/detail/GroupDetailViewModel.kt
@@ -45,7 +45,6 @@ class GroupDetailViewModel @Inject constructor(
                         when (notification) {
                             is StartNotification -> notification.startedAt
                             is FinishNotification -> notification.runningHistory.startedAt
-                            else -> 0
                         }
                     }
         }.launchIn(viewModelScope)

--- a/presentation/src/main/java/com/whyranoid/presentation/community/group/detail/GroupDetailViewModel.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/community/group/detail/GroupDetailViewModel.kt
@@ -1,0 +1,72 @@
+package com.whyranoid.presentation.community.group.detail
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.whyranoid.domain.model.FinishNotification
+import com.whyranoid.domain.model.GroupNotification
+import com.whyranoid.domain.model.StartNotification
+import com.whyranoid.domain.usecase.GetGroupNotificationsUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class GroupDetailViewModel @Inject constructor(
+    getGroupNotificationsUseCase: GetGroupNotificationsUseCase
+) : ViewModel() {
+
+    private val _eventFlow = MutableSharedFlow<Event>()
+    val eventFlow: SharedFlow<Event>
+        get() = _eventFlow.asSharedFlow()
+
+    private val startNotification = MutableStateFlow<List<GroupNotification>>(emptyList())
+    private val finishNotification = MutableStateFlow<List<GroupNotification>>(emptyList())
+    val mergedNotifications = MutableStateFlow<List<GroupNotification>>(emptyList())
+
+    init {
+        // TODO : 그룹 아이디를 프레그먼트에서 받아오도록 변경
+        getGroupNotificationsUseCase("수피치 그룹1").onEach { notifications ->
+
+            if (notifications.isNotEmpty() && notifications.first() is StartNotification) {
+                startNotification.value = notifications
+            } else {
+                finishNotification.value = notifications
+            }
+
+            mergedNotifications.value =
+                (startNotification.value + finishNotification.value)
+                    .sortedBy { notification ->
+                        when (notification) {
+                            is StartNotification -> notification.startedAt
+                            is FinishNotification -> notification.runningHistory.startedAt
+                            else -> 0
+                        }
+                    }
+        }.launchIn(viewModelScope)
+    }
+
+    fun onRecruitButtonClicked() {
+        emitEvent(Event.RecruitButtonClick)
+    }
+
+    fun onExitGroupButtonClicked() {
+        emitEvent(Event.ExitGroupButtonClick)
+    }
+
+    private fun emitEvent(event: Event) {
+        when (event) {
+            Event.RecruitButtonClick,
+            Event.ExitGroupButtonClick -> {
+                viewModelScope.launch {
+                    _eventFlow.emit(event)
+                }
+            }
+        }
+    }
+}

--- a/presentation/src/main/java/com/whyranoid/presentation/community/group/detail/GroupNotificationAdapter.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/community/group/detail/GroupNotificationAdapter.kt
@@ -1,0 +1,145 @@
+package com.whyranoid.presentation.community.group.detail
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.databinding.ViewDataBinding
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.whyranoid.domain.model.FinishNotification
+import com.whyranoid.domain.model.GroupNotification
+import com.whyranoid.domain.model.StartNotification
+import com.whyranoid.presentation.databinding.MyFinishNotificationItemBinding
+import com.whyranoid.presentation.databinding.MyStartNotificationItemBinding
+import com.whyranoid.presentation.databinding.OtherFinishNotificationItemBinding
+import com.whyranoid.presentation.databinding.OtherStartNotificationItemBinding
+
+class GroupNotificationAdapter(private val myUid: String) :
+    ListAdapter<GroupNotification, GroupNotificationAdapter.NotificationViewHolder>(
+        notificationDiffUtil
+    ) {
+
+    companion object {
+        private val notificationDiffUtil = object : DiffUtil.ItemCallback<GroupNotification>() {
+            override fun areItemsTheSame(
+                oldItem: GroupNotification,
+                newItem: GroupNotification
+            ): Boolean =
+                oldItem == newItem
+
+            override fun areContentsTheSame(
+                oldItem: GroupNotification,
+                newItem: GroupNotification
+            ): Boolean =
+                oldItem.uid == newItem.uid
+        }
+
+        const val MY_START_NOTIFICATION_TYPE = 0
+        const val MY_FINISH_NOTIFICATION_TYPE = 1
+        const val OTHER_START_NOTIFICATION_TYPE = 2
+        const val OTHER_FINISH_NOTIFICATION_TYPE = 3
+    }
+
+    abstract class NotificationViewHolder(binding: ViewDataBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+        abstract fun bind(notification: GroupNotification)
+    }
+
+    class MyStartNotificationViewHolder(private val binding: MyStartNotificationItemBinding) :
+        NotificationViewHolder(binding) {
+
+        override fun bind(notification: GroupNotification) {
+            if (notification is StartNotification) {
+                binding.notifications = notification
+            }
+        }
+    }
+
+    class MyFinishNotificationViewHolder(private val binding: MyFinishNotificationItemBinding) :
+        NotificationViewHolder(binding) {
+
+        override fun bind(notification: GroupNotification) {
+            if (notification is FinishNotification) {
+                binding.notifications = notification
+            }
+        }
+    }
+
+    class OtherStartNotificationViewHolder(private val binding: OtherStartNotificationItemBinding) :
+        NotificationViewHolder(binding) {
+
+        override fun bind(notification: GroupNotification) {
+            if (notification is StartNotification) {
+                binding.notifications = notification
+            }
+        }
+    }
+
+    class OtherFinishNotificationViewHolder(private val binding: OtherFinishNotificationItemBinding) :
+        NotificationViewHolder(binding) {
+
+        override fun bind(notification: GroupNotification) {
+            if (notification is FinishNotification) {
+                binding.notifications = notification
+            }
+        }
+    }
+
+    override fun getItemViewType(position: Int): Int {
+        return when (val notification = getItem(position)) {
+            is StartNotification -> {
+                if (notification.uid == myUid) MY_START_NOTIFICATION_TYPE
+                else OTHER_START_NOTIFICATION_TYPE
+            }
+            else -> {
+                if (notification.uid == myUid) MY_FINISH_NOTIFICATION_TYPE
+                else OTHER_FINISH_NOTIFICATION_TYPE
+            }
+        }
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): NotificationViewHolder {
+        return when (viewType) {
+            MY_START_NOTIFICATION_TYPE -> {
+                val layoutInflater =
+                    MyStartNotificationItemBinding.inflate(
+                        LayoutInflater.from(parent.context),
+                        parent,
+                        false
+                    )
+                MyStartNotificationViewHolder(layoutInflater)
+            }
+            MY_FINISH_NOTIFICATION_TYPE -> {
+                val layoutInflater =
+                    MyFinishNotificationItemBinding.inflate(
+                        LayoutInflater.from(parent.context),
+                        parent,
+                        false
+                    )
+                MyFinishNotificationViewHolder(layoutInflater)
+            }
+            OTHER_START_NOTIFICATION_TYPE -> {
+                val layoutInflater =
+                    OtherStartNotificationItemBinding.inflate(
+                        LayoutInflater.from(parent.context),
+                        parent,
+                        false
+                    )
+                OtherStartNotificationViewHolder(layoutInflater)
+            }
+            else -> {
+                val layoutInflater =
+                    OtherFinishNotificationItemBinding.inflate(
+                        LayoutInflater.from(parent.context),
+                        parent,
+                        false
+                    )
+                OtherFinishNotificationViewHolder(layoutInflater)
+            }
+        }
+    }
+
+    override fun onBindViewHolder(holder: NotificationViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+}

--- a/presentation/src/main/java/com/whyranoid/presentation/community/group/detail/GroupSettingDialog.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/community/group/detail/GroupSettingDialog.kt
@@ -1,0 +1,48 @@
+package com.whyranoid.presentation.community.group.detail
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import com.whyranoid.presentation.databinding.GroupSettingDialogBinding
+
+class GroupSettingDialog(
+    private val onEditButtonClickListener: () -> Unit,
+    private val onDeleteButtonClickListener: () -> Unit
+) : BottomSheetDialogFragment() {
+
+    companion object {
+        const val TAG = "GroupSettingDialog"
+    }
+
+    lateinit var binding: GroupSettingDialogBinding
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        super.onCreateView(inflater, container, savedInstanceState)
+        binding = GroupSettingDialogBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        binding.btnEditGroup.setOnClickListener {
+            onEditButtonClickListener.invoke()
+            dismiss()
+        }
+
+        binding.btnDeleteGroup.setOnClickListener {
+            onDeleteButtonClickListener.invoke()
+            dismiss()
+        }
+
+        binding.btnCancel.setOnClickListener {
+            dismiss()
+        }
+    }
+}

--- a/presentation/src/main/java/com/whyranoid/presentation/community/group/detail/GroupSettingDialog.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/community/group/detail/GroupSettingDialog.kt
@@ -30,19 +30,24 @@ class GroupSettingDialog(
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        setButtons()
+    }
 
-        binding.btnEditGroup.setOnClickListener {
-            onEditButtonClickListener.invoke()
-            dismiss()
-        }
+    private fun setButtons() {
+        with(binding) {
+            btnEditGroup.setOnClickListener {
+                onEditButtonClickListener.invoke()
+                dismiss()
+            }
 
-        binding.btnDeleteGroup.setOnClickListener {
-            onDeleteButtonClickListener.invoke()
-            dismiss()
-        }
+            btnDeleteGroup.setOnClickListener {
+                onDeleteButtonClickListener.invoke()
+                dismiss()
+            }
 
-        binding.btnCancel.setOnClickListener {
-            dismiss()
+            btnCancel.setOnClickListener {
+                dismiss()
+            }
         }
     }
 }

--- a/presentation/src/main/java/com/whyranoid/presentation/model/GroupInfoUiModel.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/model/GroupInfoUiModel.kt
@@ -1,0 +1,27 @@
+package com.whyranoid.presentation.model
+
+import android.os.Parcelable
+import com.whyranoid.domain.model.GroupInfo
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class GroupInfoUiModel(
+    val name: String,
+    val groupId: String,
+    val introduce: String,
+    val rules: List<RuleUiModel>,
+    val headCount: Int,
+    val leader: UserUiModel
+) : Parcelable
+
+fun GroupInfo.toGroupInfoUiModel() =
+    GroupInfoUiModel(
+        name = this.name,
+        groupId = this.groupId,
+        introduce = this.introduce,
+        rules = this.rules.map { rule ->
+            rule.toRuleUiModel()
+        },
+        headCount = this.headCount,
+        leader = this.leader.toUserUiModel()
+    )

--- a/presentation/src/main/java/com/whyranoid/presentation/model/RuleUiModel.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/model/RuleUiModel.kt
@@ -1,0 +1,24 @@
+package com.whyranoid.presentation.model
+
+import android.os.Parcelable
+import com.whyranoid.domain.model.DayOfWeek
+import com.whyranoid.domain.model.Rule
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class RuleUiModel(
+    val dayOfWeek: DayOfWeek,
+    val hour: Int,
+    val minute: Int
+) : Parcelable {
+    override fun toString(): String {
+        return "${dayOfWeek.dayResId}-$hour-$minute"
+    }
+}
+
+fun Rule.toRuleUiModel() =
+    RuleUiModel(
+        dayOfWeek = this.dayOfWeek,
+        hour = this.hour,
+        minute = this.minute
+    )

--- a/presentation/src/main/java/com/whyranoid/presentation/model/UserUiModel.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/model/UserUiModel.kt
@@ -1,0 +1,19 @@
+package com.whyranoid.presentation.model
+
+import android.os.Parcelable
+import com.whyranoid.domain.model.User
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class UserUiModel(
+    val uid: String,
+    val name: String?,
+    val profileUrl: String?
+) : Parcelable
+
+fun User.toUserUiModel() =
+    UserUiModel(
+        uid = this.uid,
+        name = this.name,
+        profileUrl = this.profileUrl
+    )

--- a/presentation/src/main/java/com/whyranoid/presentation/util/BindingAdapters.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/util/BindingAdapters.kt
@@ -2,10 +2,13 @@ package com.whyranoid.presentation.util
 
 import android.view.View
 import android.widget.ImageView
+import android.widget.TextView
 import androidx.databinding.BindingAdapter
 import com.bumptech.glide.Glide
 import com.whyranoid.presentation.R
 import com.whyranoid.presentation.util.networkconnection.NetworkState
+import java.text.SimpleDateFormat
+import java.util.*
 
 @BindingAdapter("networkConnectionVisibility")
 fun View.networkConnectionVisibility(networkState: NetworkState) {
@@ -32,4 +35,16 @@ fun ImageView.loadImage(uri: String) {
         .error(R.drawable.thumbnail_src_small)
         .circleCrop()
         .into(this)
+}
+
+@BindingAdapter("startLongToDate")
+fun TextView.startLongToDate(long: Long) {
+    val formatter = SimpleDateFormat("yyyy.MM.dd / HH 시 mm 분 운동 시작", Locale.KOREA)
+    text = formatter.format(Date(long))
+}
+
+@BindingAdapter("finishLongToDate")
+fun TextView.finishLongToDate(long: Long) {
+    val formatter = SimpleDateFormat("yyyy.MM.dd / HH 시 mm 분 운동 종료", Locale.KOREA)
+    text = formatter.format(Date(long))
 }

--- a/presentation/src/main/res/layout/fragment_group_detail.xml
+++ b/presentation/src/main/res/layout/fragment_group_detail.xml
@@ -13,7 +13,7 @@
 
         <variable
             name="groupInfo"
-            type="com.whyranoid.domain.model.GroupInfo" />
+            type="com.whyranoid.presentation.model.GroupInfoUiModel" />
 
         <variable
             name="viewModel"

--- a/presentation/src/main/res/layout/fragment_group_detail.xml
+++ b/presentation/src/main/res/layout/fragment_group_detail.xml
@@ -1,0 +1,157 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <import type="android.view.View" />
+
+        <variable
+            name="isLeader"
+            type="Boolean" />
+
+        <variable
+            name="groupInfo"
+            type="com.whyranoid.domain.model.GroupInfo" />
+
+        <variable
+            name="viewModel"
+            type="com.whyranoid.presentation.community.group.detail.GroupDetailViewModel" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <com.google.android.material.appbar.AppBarLayout
+            android:id="@+id/app_bar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <com.google.android.material.appbar.MaterialToolbar
+                android:id="@+id/top_app_bar"
+                style="@style/Widget.MaterialComponents.Toolbar.Primary"
+                android:layout_width="match_parent"
+                android:layout_height="?attr/actionBarSize"
+                app:title="@{groupInfo.name}"
+                tools:title ="수피치 그룹"/>
+
+        </com.google.android.material.appbar.AppBarLayout>
+
+        <androidx.core.widget.NestedScrollView
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/app_bar"
+            app:layout_constraintBottom_toBottomOf="parent"
+            android:background="@color/mogakrun_secondary">
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                tools:context=".community.group.detail.GroupDetailFragment">
+
+                <TextView
+                    android:id="@+id/tv_group_name"
+                    style="@style/MoGakRunText.ExtraBold"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="16dp"
+                    android:gravity="center"
+                    android:text="@{groupInfo.name}"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"
+                    tools:text="수피치와 함께 춤을\n출까 말까" />
+
+                <TextView
+                    android:id="@+id/tv_group_introduce"
+                    style="@style/MoGakRunText.Bold.Large"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="16dp"
+                    android:gravity="center"
+                    android:text="@{groupInfo.introduce}"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/tv_group_name"
+                    tools:text="우리 그룹은요\n이러쿵\n저러쿵\n이렇고요\n저렇고요" />
+
+                <TextView
+                    android:id="@+id/tv_rules"
+                    style="@style/MoGakRunText.Bold.Medium"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="16dp"
+                    android:gravity="center"
+                    android:text="@{groupInfo.rules.toString()}"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/tv_group_introduce"
+                    tools:text="규칙들\n이 적히게\n됩니다." />
+
+                <TextView
+                    android:id="@+id/tv_head_count"
+                    style="@style/MoGakRunText.Bold.Medium"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="16dp"
+                    android:gravity="center"
+                    android:text="@{@string/text_headcount(groupInfo.headCount)}"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/tv_rules"
+                    tools:text="40명" />
+
+                <TextView
+                    android:id="@+id/tv_leader"
+                    style="@style/MoGakRunText.Bold.Medium"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="16dp"
+                    android:gravity="center"
+                    android:text="@{groupInfo.leader.name}"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/tv_rules"
+                    tools:text="수피치" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/btn_recruit"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="16dp"
+                    android:text="@string/text_recruit"
+                    android:onClick="@{() -> viewModel.onRecruitButtonClicked()}"
+                    android:visibility="@{isLeader ? View.VISIBLE : View.INVISIBLE}"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/tv_head_count" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/btn_exit_group"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="16dp"
+                    android:text="@string/text_exit_group"
+                    android:onClick="@{() -> viewModel.onExitGroupButtonClicked()}"
+                    android:visibility="@{isLeader ? View.GONE : View.VISIBLE}"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/tv_head_count" />
+
+                <androidx.recyclerview.widget.RecyclerView
+                    android:id="@+id/notification_recycler_view"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="16dp"
+                    app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/btn_recruit" />
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
+
+        </androidx.core.widget.NestedScrollView>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/presentation/src/main/res/layout/group_setting_dialog.xml
+++ b/presentation/src/main/res/layout/group_setting_dialog.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <data>
+
+    </data>
+
+    <androidx.coordinatorlayout.widget.CoordinatorLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@color/mogakrun_primary">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:padding="12dp">
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btn_edit_group"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_margin="16dp"
+                android:backgroundTint="@color/mogakrun_secondary_dark"
+                android:text="@string/text_edit_group"
+                android:textColor="@color/mogakrun_on_secondary"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btn_delete_group"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_margin="16dp"
+                android:backgroundTint="@color/mogakrun_secondary_dark"
+                android:text="@string/text_delete_group"
+                android:textColor="@color/mogakrun_on_secondary"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/btn_edit_group" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btn_cancel"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_margin="16dp"
+                android:backgroundTint="@color/mogakrun_secondary_dark"
+                android:text="@string/text_cancel"
+                android:textColor="@color/mogakrun_on_secondary"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/btn_delete_group" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </androidx.coordinatorlayout.widget.CoordinatorLayout>
+
+</layout>

--- a/presentation/src/main/res/layout/my_finish_notification_item.xml
+++ b/presentation/src/main/res/layout/my_finish_notification_item.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+        <variable
+            name="notifications"
+            type="com.whyranoid.domain.model.FinishNotification" />
+    </data>
+
+    <androidx.cardview.widget.CardView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="8dp"
+        android:elevation="10dp"
+        app:cardCornerRadius="20dp">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@color/mogakrun_secondary_light"
+            android:padding="8dp"
+            android:paddingBottom="16dp">
+
+            <TextView
+                android:id="@+id/tv_end_notification"
+                style="@style/MoGakRunText.Bold.Medium"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_margin="8dp"
+                android:gravity="end"
+                app:finishLongToDate="@{notifications.runningHistory.finishedAt}"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                tools:text="2022.11.21 / 21 시 10분 운동 종료"/>
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </androidx.cardview.widget.CardView>
+</layout>

--- a/presentation/src/main/res/layout/my_start_notification_item.xml
+++ b/presentation/src/main/res/layout/my_start_notification_item.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="notifications"
+            type="com.whyranoid.domain.model.StartNotification" />
+    </data>
+
+    <androidx.cardview.widget.CardView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="8dp"
+        android:elevation="10dp"
+        app:cardCornerRadius="20dp">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@color/mogakrun_primary"
+            android:padding="8dp"
+            android:paddingBottom="16dp">
+
+            <TextView
+                android:id="@+id/tv_start_notification"
+                style="@style/MoGakRunText.Bold.Medium"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_margin="8dp"
+                android:gravity="end"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:startLongToDate="@{notifications.startedAt}"
+                tools:text="2022.11.21 / 21 시 10분 운동 시작" />
+
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </androidx.cardview.widget.CardView>
+</layout>

--- a/presentation/src/main/res/layout/other_finish_notification_item.xml
+++ b/presentation/src/main/res/layout/other_finish_notification_item.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+        <variable
+            name="notifications"
+            type="com.whyranoid.domain.model.FinishNotification" />
+    </data>
+
+    <androidx.cardview.widget.CardView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="8dp"
+        android:elevation="10dp"
+        app:cardCornerRadius="20dp">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@color/mogakrun_secondary_dark"
+            android:padding="8dp"
+            android:paddingBottom="16dp"
+            >
+
+            <TextView
+                android:id="@+id/tv_uid"
+                style="@style/MoGakRunText.Bold.Large"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_margin="8dp"
+                android:text="@{notifications.uid}"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                tools:text="수피치"/>
+
+            <TextView
+                android:id="@+id/tv_end_notification"
+                style="@style/MoGakRunText.Bold.Medium"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_margin="8dp"
+                android:gravity="start"
+                app:finishLongToDate="@{notifications.runningHistory.finishedAt}"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/tv_uid"
+                tools:text="2022.11.21 / 21 시 10분 운동 종료"/>
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </androidx.cardview.widget.CardView>
+</layout>

--- a/presentation/src/main/res/layout/other_start_notification_item.xml
+++ b/presentation/src/main/res/layout/other_start_notification_item.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+        <variable
+            name="notifications"
+            type="com.whyranoid.domain.model.StartNotification" />
+    </data>
+
+    <androidx.cardview.widget.CardView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="8dp"
+        android:elevation="10dp"
+        app:cardCornerRadius="20dp">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/mogakrun_primary_dark"
+        android:padding="8dp"
+        android:paddingBottom="16dp">
+
+        <TextView
+            android:id="@+id/tv_uid"
+            style="@style/MoGakRunText.Bold.Large"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_margin="8dp"
+            android:text="@{notifications.uid}"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="수피치"/>
+
+        <TextView
+            android:id="@+id/tv_start_notification"
+            style="@style/MoGakRunText.Bold.Medium"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_margin="8dp"
+            android:gravity="start"
+            app:startLongToDate="@{notifications.startedAt}"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_uid"
+            tools:text="2022.11.21 / 21 시 10분 운동 시작"/>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+    </androidx.cardview.widget.CardView>
+</layout>

--- a/presentation/src/main/res/menu/group_detail_menu.xml
+++ b/presentation/src/main/res/menu/group_detail_menu.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:id="@+id/setting_group"
+        android:enabled="true"
+        android:icon="@drawable/my_run_tool_bar_setting"
+        android:title="@string/text_setting_group"
+        app:showAsAction="always"/>
+</menu>

--- a/presentation/src/main/res/navigation/navigation_graph.xml
+++ b/presentation/src/main/res/navigation/navigation_graph.xml
@@ -52,7 +52,7 @@
         tools:layout="@layout/fragment_group_detail">
         <argument
             android:name="groupInfo"
-            app:argType="com.whyranoid.domain.model.GroupInfo" />
+            app:argType="com.whyranoid.presentation.model.GroupInfoUiModel" />
     </fragment>
 
 </navigation>

--- a/presentation/src/main/res/navigation/navigation_graph.xml
+++ b/presentation/src/main/res/navigation/navigation_graph.xml
@@ -36,11 +36,23 @@
         <action
             android:id="@+id/action_communityFragment_to_createGroupFragment"
             app:destination="@id/createGroupFragment" />
+        <action
+            android:id="@+id/action_communityFragment_to_groupDetailFragment"
+            app:destination="@id/groupDetailFragment" />
     </fragment>
     <fragment
         android:id="@+id/createGroupFragment"
         android:name="com.whyranoid.presentation.community.group.CreateGroupFragment"
         android:label="CreateGroupFragment"
         tools:layout="@layout/fragment_create_group"/>
+    <fragment
+        android:id="@+id/groupDetailFragment"
+        android:name="com.whyranoid.presentation.community.group.detail.GroupDetailFragment"
+        android:label="GroupDetailFragment"
+        tools:layout="@layout/fragment_group_detail">
+        <argument
+            android:name="groupInfo"
+            app:argType="com.whyranoid.domain.model.GroupInfo" />
+    </fragment>
 
 </navigation>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -55,5 +55,8 @@
     <string name="text_recruit">홍보하기</string>
     <string name="text_exit_group">그룹 나가기</string>
     <string name="text_setting_group">그룹 설정</string>
+    <string name="text_edit_group">그룹 수정하기</string>
+    <string name="text_delete_group">그룹 삭제하기</string>
+    <string name="text_cancel">취소</string>
 
 </resources>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -50,4 +50,9 @@
     <string name="text_create_group_fail">그룹 생성에 실패하였습니다.</string>
     <string name="text_select_rule">규칙 고르기</string>
 
+    <!-- 그룹 상세보기 화면-->
+    <string name="text_headcount">%d명</string>
+    <string name="text_recruit">홍보하기</string>
+    <string name="text_exit_group">그룹 나가기</string>
+
 </resources>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -54,5 +54,6 @@
     <string name="text_headcount">%d명</string>
     <string name="text_recruit">홍보하기</string>
     <string name="text_exit_group">그룹 나가기</string>
+    <string name="text_setting_group">그룹 설정</string>
 
 </resources>


### PR DESCRIPTION
## 😎 작업 내용
- 그룹 상세보기 페이지 구현
  - 화면 및 이벤트 처리 구현
  - Ui에서 사용할 UiModel들 추가
## 🧐 변경된 내용
- null

## 🥳 동작 화면
- 내 그룹 리스트에서 그룹 상세페이지로 이동
 ![toDetail](https://user-images.githubusercontent.com/90144041/203774720-cda7c1f9-1fbf-4a37-a82e-59869af5c1f0.gif)

- 내가 그룹장이라면 그룹 설정 버튼 및 홍보하기 버튼이 보여짐. 그룹장이 아니라면 그룹 나가기 버튼이 보여짐.
![isLeader](https://user-images.githubusercontent.com/90144041/203775096-9e5c0b1c-75f2-4cc1-8a29-8d4b83b9c203.gif)

- 총 4개의 뷰타입으로 알림 레이아웃을 구현.(나의 시작 알림, 나의 종료 알림, 상대의 시작 알림, 상대의 종료 알림)
![notifications](https://user-images.githubusercontent.com/90144041/203775406-09024dda-5f81-4772-8139-3ab9c1fcb020.gif)


## 🤯 이슈 번호
- #36 
