### PR TITLE
홍보 글 작성 기능 구현, 홍보 글 불러오기 기능 구현

### DIFF
--- a/data/src/main/java/com/whyranoid/data/Post/PostDataSource.kt
+++ b/data/src/main/java/com/whyranoid/data/Post/PostDataSource.kt
@@ -3,13 +3,17 @@ package com.whyranoid.data.Post
 import com.google.firebase.firestore.FirebaseFirestore
 import com.whyranoid.data.constant.CollectionId
 import com.whyranoid.data.model.GroupInfoResponse
+import com.whyranoid.data.model.RecruitPostResponse
 import com.whyranoid.data.model.UserResponse
 import com.whyranoid.data.model.toGroupInfo
 import com.whyranoid.data.model.toUser
+import com.whyranoid.domain.model.Post
 import com.whyranoid.domain.model.RecruitPost
 import com.whyranoid.domain.model.toRule
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.suspendCancellableCoroutine
-import kotlinx.coroutines.tasks.await
 import java.util.*
 import javax.inject.Inject
 import kotlin.coroutines.resume
@@ -18,49 +22,80 @@ class PostDataSource @Inject constructor(
     private val db: FirebaseFirestore
 ) {
 
+    //  TODO : 타입을 확인하고 캐스팅하는 부분 필요
+    fun getAllPostFlow(): Flow<List<Post>> =
+        callbackFlow {
+            db.collection(CollectionId.POST_COLLECTION)
+                .addSnapshotListener { snapshot, _ ->
+                    val recruitPostList = mutableListOf<Post>()
+                    snapshot?.forEach { docuemnt ->
+                        docuemnt.toObject(RecruitPostResponse::class.java).let { postResponse ->
+
+                            db.collection(CollectionId.USERS_COLLECTION)
+                                .document(postResponse.authorId)
+                                .get()
+                                .addOnSuccessListener { authorDocument ->
+                                    val authorResponse =
+                                        authorDocument?.toObject(UserResponse::class.java)
+
+                                    authorResponse?.let {
+                                        db.collection(CollectionId.GROUPS_COLLECTION)
+                                            .document(postResponse.groupId)
+                                            .get()
+                                            .addOnSuccessListener { groupDocument ->
+                                                val groupInfoResponse =
+                                                    groupDocument.toObject(GroupInfoResponse::class.java)
+
+                                                groupInfoResponse?.let { groupInfoResponse ->
+                                                    val author = authorResponse.toUser()
+                                                    recruitPostList.add(
+                                                        RecruitPost(
+                                                            postId = postResponse.postId,
+                                                            author = author,
+                                                            updatedAt = postResponse.updatedAt,
+                                                            groupInfo = groupInfoResponse
+                                                                .toGroupInfo(
+                                                                    author,
+                                                                    rules = groupInfoResponse.rules.map {
+                                                                        it.toRule()
+                                                                    }
+                                                                )
+                                                        )
+                                                    )
+                                                    trySend(recruitPostList)
+                                                }
+                                            }
+                                    }
+                                }
+                        }
+                    }
+                }
+
+            awaitClose()
+        }
+
     suspend fun createRecruitPost(
         authorUid: String,
         groupUid: String
     ): Boolean {
         val postId = UUID.randomUUID().toString()
 
-        val author = db.collection(CollectionId.USERS_COLLECTION)
-            .document(authorUid)
-            .get()
-            .await()
-            .toObject(UserResponse::class.java)
-            ?.toUser()
+        return suspendCancellableCoroutine { cancellableContinuation ->
 
-        author?.let {
-            val groupInfo = db.collection(CollectionId.GROUPS_COLLECTION)
-                .document(groupUid)
-                .get()
-                .await()
-                .toObject(GroupInfoResponse::class.java)
-
-            groupInfo?.let {
-                return suspendCancellableCoroutine { cancellableContinuation ->
-
-                    db.collection(CollectionId.POST_COLLECTION)
-                        .document(postId)
-                        .set(
-                            RecruitPost(
-                                postId = postId,
-                                author = author,
-                                updatedAt = System.currentTimeMillis(),
-                                groupInfo = groupInfo.toGroupInfo(
-                                    leader = author,
-                                    rules = groupInfo.rules.map { it.toRule() }
-                                )
-                            )
-                        ).addOnSuccessListener {
-                            cancellableContinuation.resume(true)
-                        }.addOnFailureListener {
-                            cancellableContinuation.resume(false)
-                        }
+            db.collection(CollectionId.POST_COLLECTION)
+                .document(postId)
+                .set(
+                    RecruitPostResponse(
+                        postId = postId,
+                        authorId = authorUid,
+                        updatedAt = System.currentTimeMillis(),
+                        groupId = groupUid
+                    )
+                ).addOnSuccessListener {
+                    cancellableContinuation.resume(true)
+                }.addOnFailureListener {
+                    cancellableContinuation.resume(false)
                 }
-            }
         }
-        return false
     }
 }

--- a/data/src/main/java/com/whyranoid/data/Post/PostDataSource.kt
+++ b/data/src/main/java/com/whyranoid/data/Post/PostDataSource.kt
@@ -20,7 +20,6 @@ class PostDataSource @Inject constructor(
 
     suspend fun createRecruitPost(
         authorUid: String,
-        updatedAt: Long,
         groupUid: String
     ): Boolean {
         val postId = UUID.randomUUID().toString()
@@ -48,7 +47,7 @@ class PostDataSource @Inject constructor(
                             RecruitPost(
                                 postId = postId,
                                 author = author,
-                                updatedAt = updatedAt,
+                                updatedAt = System.currentTimeMillis(),
                                 groupInfo = groupInfo.toGroupInfo(
                                     leader = author,
                                     rules = groupInfo.rules.map { it.toRule() }

--- a/data/src/main/java/com/whyranoid/data/Post/PostRepositoryImpl.kt
+++ b/data/src/main/java/com/whyranoid/data/Post/PostRepositoryImpl.kt
@@ -16,6 +16,10 @@ class PostRepositoryImpl @Inject constructor(
         TODO("Not yet implemented")
     }
 
+    override fun getAllPostFlow(): Flow<List<Post>> {
+        return postDataSource.getAllPostFlow()
+    }
+
     override suspend fun createPost(
         user: User,
         postContent: String,

--- a/data/src/main/java/com/whyranoid/data/Post/PostRepositoryImpl.kt
+++ b/data/src/main/java/com/whyranoid/data/Post/PostRepositoryImpl.kt
@@ -27,10 +27,9 @@ class PostRepositoryImpl @Inject constructor(
 
     override suspend fun createRecruitPost(
         authorUid: String,
-        updatedAt: Long,
         groupUid: String
     ): Boolean {
-        return postDataSource.createRecruitPost(authorUid, updatedAt, groupUid)
+        return postDataSource.createRecruitPost(authorUid, groupUid)
     }
 
     override suspend fun deletePost(postId: String): Boolean {

--- a/data/src/main/java/com/whyranoid/data/model/PostResponse.kt
+++ b/data/src/main/java/com/whyranoid/data/model/PostResponse.kt
@@ -2,13 +2,13 @@ package com.whyranoid.data.model
 
 sealed interface PostResponse {
     val postId: String
-    val author: String
+    val authorId: String
     val updatedAt: Long
 }
 
 data class RecruitPostResponse(
+    override val authorId: String = "",
+    val groupId: String = "",
     override val postId: String = "",
-    override val author: String = "",
-    override val updatedAt: Long = 0L,
-    val groupUid: String = ""
+    override val updatedAt: Long = 0L
 ) : PostResponse

--- a/domain/src/main/java/com/whyranoid/domain/repository/PostRepository.kt
+++ b/domain/src/main/java/com/whyranoid/domain/repository/PostRepository.kt
@@ -11,6 +11,8 @@ interface PostRepository {
     // 글(홍보 / 인증) 페이징으로 가져오기 - 리모트
     fun getPagingPosts(): Flow<List<Post>>
 
+    fun getAllPostFlow(): Flow<List<Post>>
+
     // 글 작성하기 - 리모트
     suspend fun createPost(
         user: User,

--- a/domain/src/main/java/com/whyranoid/domain/repository/PostRepository.kt
+++ b/domain/src/main/java/com/whyranoid/domain/repository/PostRepository.kt
@@ -21,7 +21,6 @@ interface PostRepository {
 
     suspend fun createRecruitPost(
         authorUid: String,
-        updatedAt: Long,
         groupUid: String
     ): Boolean
 

--- a/domain/src/main/java/com/whyranoid/domain/usecase/CreateRecruitPostUseCase.kt
+++ b/domain/src/main/java/com/whyranoid/domain/usecase/CreateRecruitPostUseCase.kt
@@ -1,0 +1,18 @@
+package com.whyranoid.domain.usecase
+
+import com.whyranoid.domain.repository.AccountRepository
+import com.whyranoid.domain.repository.PostRepository
+import javax.inject.Inject
+
+class CreateRecruitPostUseCase @Inject constructor(
+    private val postRepository: PostRepository,
+    private val accountRepository: AccountRepository
+) {
+    // TODO : accountRepository에서 User를 가져오도록 수정
+    suspend operator fun invoke(
+        authorUid: String,
+        groupUid: String
+    ): Boolean {
+        return postRepository.createRecruitPost(authorUid, groupUid)
+    }
+}

--- a/domain/src/main/java/com/whyranoid/domain/usecase/GetPostsUseCase.kt
+++ b/domain/src/main/java/com/whyranoid/domain/usecase/GetPostsUseCase.kt
@@ -1,0 +1,15 @@
+package com.whyranoid.domain.usecase
+
+import com.whyranoid.domain.model.Post
+import com.whyranoid.domain.repository.PostRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class GetPostsUseCase @Inject constructor(
+    private val postRepository: PostRepository
+) {
+
+    operator fun invoke(): Flow<List<Post>> {
+        return postRepository.getAllPostFlow()
+    }
+}

--- a/presentation/src/main/java/com/whyranoid/presentation/community/CommunityItemFragment.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/community/CommunityItemFragment.kt
@@ -40,6 +40,7 @@ internal class CommunityItemFragment :
         when (category) {
             CommunityCategory.BOARD -> {
                 // TODO: Adapter 설정
+                setPostAdapter()
             }
             CommunityCategory.MY_GROUP -> {
                 setMyGroupAdapter()
@@ -64,6 +65,19 @@ internal class CommunityItemFragment :
                 val action =
                     CommunityFragmentDirections.actionCommunityFragmentToGroupDetailFragment(event.groupInfo)
                 findNavController().navigate(action)
+            }
+        }
+    }
+
+    private fun setPostAdapter() {
+        // TODO uid를 데이터 소스에서 가져오도록 수정
+        val postAdapter = PostAdapter("hsjeon")
+        binding.rvCommunity.adapter = postAdapter
+
+        viewLifecycleOwner.repeatWhenUiStarted {
+            viewModel.postList.collect { postList ->
+                removeShimmer()
+                postAdapter.submitList(postList)
             }
         }
     }

--- a/presentation/src/main/java/com/whyranoid/presentation/community/CommunityViewModel.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/community/CommunityViewModel.kt
@@ -2,7 +2,9 @@ package com.whyranoid.presentation.community
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.whyranoid.domain.model.Post
 import com.whyranoid.domain.usecase.GetMyGroupListUseCase
+import com.whyranoid.domain.usecase.GetPostsUseCase
 import com.whyranoid.presentation.model.GroupInfoUiModel
 import com.whyranoid.presentation.model.toGroupInfoUiModel
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -19,8 +21,13 @@ import javax.inject.Inject
 
 @HiltViewModel
 class CommunityViewModel @Inject constructor(
-    getMyGroupListUseCase: GetMyGroupListUseCase
+    getMyGroupListUseCase: GetMyGroupListUseCase,
+    getPostsUseCase: GetPostsUseCase
 ) : ViewModel() {
+
+    private val _postList = MutableStateFlow<List<Post>>(emptyList())
+    val postList: StateFlow<List<Post>>
+        get() = _postList.asStateFlow()
 
     private val _myGroupList = MutableStateFlow<List<GroupInfoUiModel>>(emptyList())
     val myGroupList: StateFlow<List<GroupInfoUiModel>>
@@ -45,6 +52,10 @@ class CommunityViewModel @Inject constructor(
             _myGroupList.value = groupInfoList.map { groupInfo ->
                 groupInfo.toGroupInfoUiModel()
             }
+        }.launchIn(viewModelScope)
+
+        getPostsUseCase().onEach { postList ->
+            _postList.value = postList
         }.launchIn(viewModelScope)
     }
 }

--- a/presentation/src/main/java/com/whyranoid/presentation/community/PostAdapter.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/community/PostAdapter.kt
@@ -1,0 +1,54 @@
+package com.whyranoid.presentation.community
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.whyranoid.domain.model.Post
+import com.whyranoid.domain.model.RecruitPost
+import com.whyranoid.presentation.databinding.ItemRecruitPostBinding
+
+class PostAdapter(private val myUid: String) :
+    ListAdapter<Post, PostAdapter.RecruitPostViewHolder>(diffUtil) {
+
+    companion object {
+        val diffUtil = object : DiffUtil.ItemCallback<Post>() {
+            override fun areItemsTheSame(oldItem: Post, newItem: Post) =
+                oldItem.postId == newItem.postId
+
+            override fun areContentsTheSame(oldItem: Post, newItem: Post) =
+                oldItem == newItem
+        }
+    }
+
+    inner class RecruitPostViewHolder(
+        parent: ViewGroup,
+        private val binding: ItemRecruitPostBinding = ItemRecruitPostBinding.inflate(
+            LayoutInflater.from(parent.context),
+            parent,
+            false
+        )
+    ) : RecyclerView.ViewHolder(binding.root) {
+        fun bind(post: Post) {
+            if (post is RecruitPost) {
+                binding.recruitPost = post
+                if (myUid == post.author.uid) {
+                    println("테스트 $myUid ${post.author.uid}")
+                    binding.btnJoinGroup.visibility = View.GONE
+                } else {
+                    binding.btnJoinGroup.visibility = View.VISIBLE
+                }
+            }
+        }
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecruitPostViewHolder {
+        return RecruitPostViewHolder(parent)
+    }
+
+    override fun onBindViewHolder(holder: RecruitPostViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+}

--- a/presentation/src/main/java/com/whyranoid/presentation/community/group/detail/Event.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/community/group/detail/Event.kt
@@ -3,4 +3,5 @@ package com.whyranoid.presentation.community.group.detail
 sealed class Event {
     object RecruitButtonClick : Event()
     object ExitGroupButtonClick : Event()
+    data class RecruitSnackBarButtonClick(val isSuccess: Boolean = true) : Event()
 }

--- a/presentation/src/main/java/com/whyranoid/presentation/community/group/detail/GroupDetailFragment.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/community/group/detail/GroupDetailFragment.kt
@@ -76,9 +76,11 @@ internal class GroupDetailFragment :
                     Event.RecruitButtonClick -> {
                         Snackbar.make(
                             binding.root,
-                            getString(R.string.text_recruit),
+                            getString(R.string.text_check_recruit),
                             Snackbar.LENGTH_SHORT
-                        ).show()
+                        ).setAction(R.string.text_recruit) {
+                            viewModel.onRecruitSnackBarButtonClick()
+                        }.show()
                     }
                     // TODO : 그룹 나가기
                     Event.ExitGroupButtonClick -> {
@@ -87,6 +89,21 @@ internal class GroupDetailFragment :
                             getString(R.string.text_exit_group),
                             Snackbar.LENGTH_SHORT
                         ).show()
+                    }
+                    is Event.RecruitSnackBarButtonClick -> {
+                        if (event.isSuccess) {
+                            Snackbar.make(
+                                binding.root,
+                                getString(R.string.text_recruit_success),
+                                Snackbar.LENGTH_SHORT
+                            ).show()
+                        } else {
+                            Snackbar.make(
+                                binding.root,
+                                getString(R.string.text_recruit_fail),
+                                Snackbar.LENGTH_SHORT
+                            ).show()
+                        }
                     }
                 }
             }

--- a/presentation/src/main/res/layout/item_recruit_post.xml
+++ b/presentation/src/main/res/layout/item_recruit_post.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="recruitPost"
+            type="com.whyranoid.domain.model.RecruitPost" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <ImageView
+            android:id="@+id/iv_leader_profile"
+            loadImage="@{recruitPost.author.profileUrl}"
+            android:layout_width="50dp"
+            android:layout_height="50dp"
+            android:layout_margin="16dp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/tv_leader_name"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_margin="16dp"
+            android:text="@{recruitPost.author.name}"
+            app:layout_constraintStart_toEndOf="@id/iv_leader_profile"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="수피치" />
+
+        <TextView
+            android:id="@+id/tv_group_name"
+            style="@style/MoGakRunText.ExtraBold"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_margin="16dp"
+            android:layout_marginTop="16dp"
+            android:gravity="center"
+            android:text="@{recruitPost.groupInfo.name}"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_leader_name"
+            tools:text="수피치와 함께 춤을\n출까 말까" />
+
+        <TextView
+            android:id="@+id/tv_group_introduce"
+            style="@style/MoGakRunText.Bold.Large"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_margin="16dp"
+            android:gravity="center"
+            android:text="@{recruitPost.groupInfo.introduce}"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_group_name"
+            tools:text="우리 그룹은요\n이러쿵\n저러쿵\n이렇고요\n저렇고요" />
+
+        <TextView
+            android:id="@+id/tv_rules"
+            style="@style/MoGakRunText.Bold.Medium"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_margin="16dp"
+            android:gravity="center"
+            android:text="@{recruitPost.groupInfo.rules.toString()}"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_group_introduce"
+            tools:text="규칙들\n이 적히게\n됩니다." />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_join_group"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_margin="16dp"
+            android:text="@string/text_join_group"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_rules" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -86,5 +86,6 @@
     <string name="running_notification_title">달려~ 달려~</string>
     <string name="running_channel_name">활동 추적</string>
     <string name="running_channel_description">달리기 활동을 추적하는 알림 채널입니다.</string>
+    <string name="text_join_group">그룹 가입하기</string>
 
 </resources>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -70,6 +70,9 @@
     <string name="text_edit_group">그룹 수정하기</string>
     <string name="text_delete_group">그룹 삭제하기</string>
     <string name="text_cancel">취소</string>
+    <string name="text_check_recruit">정말 홍보하시겠어요?</string>
+    <string name="text_recruit_success">홍보 글이 작성되었습니다!</string>
+    <string name="text_recruit_fail">홍보 글 작성이 실패하였습니다!</string>
 
     <!-- 그룹 수정하기 화면-->
     <string name="text_edit_group_success">그룹이 수정되었습니다!</string>


### PR DESCRIPTION
## 😎 작업 내용
- 홍보 글 작성 기능 구현(홍보하기 누르면 snackbar 발생, snackbar의 action이 눌리게되면 홍보 글 생성)
  - 홍보 글 중 내가 가입하지 않은 그룹만 그룹 가입하기 버튼이 존재
- 게시글 중 홍보 글 불러오기 기능만 구현 

## 🧐 변경된 내용
- 기존에 PostResponse들은 User, GroupInfo와 같은 것들을 데이터 클래스 그대로 저장했는데 그냥 authorUid, groupUid 를 저장하는 것으로 수정.(기존에 나머지 부분이 이렇게 구현되어있기 때문에... 객체 자체를 저장하게 하면 presentation과 data가 꼬여버림)
  - 이에따라 글을 불러오는 기능도 굉장히 로직이 더러움.. 

## 🥳 동작 화면
- 홍보 글이 작성되는 모습 (수피치 그룹4)
![postRecruit](https://user-images.githubusercontent.com/90144041/204550985-700b7208-9c79-4bea-966b-c4b4ce8765fe.gif)

## 🤯 이슈 번호
- 이슈 없음

## 🥲 비고
- 현재는 게시글 탭이 홍보 글만 불러오도록 하는 중임.
  - 인증 글 작성 기능이 추가되면 DataSource에서부터 타입을 확인하고 각자 맞는 버전으로 캐스팅을 해주어야할 것 같음. 
