### PR TITLE
그룹 생성 및 수정 시 그룹 이름 중복확인 기능 추가, FinishNotifiacation관련 수정

### DIFF
--- a/data/src/main/java/com/whyranoid/data/Post/PostDataSource.kt
+++ b/data/src/main/java/com/whyranoid/data/Post/PostDataSource.kt
@@ -1,6 +1,7 @@
 package com.whyranoid.data.Post
 
 import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.Query
 import com.whyranoid.data.constant.CollectionId
 import com.whyranoid.data.model.GroupInfoResponse
 import com.whyranoid.data.model.RecruitPostResponse
@@ -26,6 +27,7 @@ class PostDataSource @Inject constructor(
     fun getAllPostFlow(): Flow<List<Post>> =
         callbackFlow {
             db.collection(CollectionId.POST_COLLECTION)
+                .orderBy("updatedAt", Query.Direction.DESCENDING)
                 .addSnapshotListener { snapshot, _ ->
                     val recruitPostList = mutableListOf<Post>()
                     snapshot?.forEach { docuemnt ->

--- a/data/src/main/java/com/whyranoid/data/constant/CollectionId.kt
+++ b/data/src/main/java/com/whyranoid/data/constant/CollectionId.kt
@@ -9,4 +9,5 @@ object CollectionId {
     const val START_NOTIFICATION = "start"
     const val FINISH_NOTIFICATION = "finish"
     const val POST_COLLECTION = "Posts"
+    const val RUNNING_HISTORY_COLLECTION = "RunningHistory"
 }

--- a/data/src/main/java/com/whyranoid/data/group/GroupDataSource.kt
+++ b/data/src/main/java/com/whyranoid/data/group/GroupDataSource.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.tasks.await
 import java.util.UUID
 import javax.inject.Inject
 import kotlin.coroutines.resume
@@ -151,5 +152,14 @@ class GroupDataSource @Inject constructor(
                 }
             }
         awaitClose()
+    }
+
+    suspend fun isDuplicatedGroupName(groupName: String): Boolean {
+        return db.collection(GROUPS_COLLECTION)
+            .whereEqualTo(GROUP_NAME, groupName)
+            .get()
+            .await()
+            .isEmpty
+            .not()
     }
 }

--- a/data/src/main/java/com/whyranoid/data/group/GroupRepositoryImpl.kt
+++ b/data/src/main/java/com/whyranoid/data/group/GroupRepositoryImpl.kt
@@ -58,4 +58,8 @@ class GroupRepositoryImpl @Inject constructor(
     ): Boolean {
         return groupDataSource.createGroup(groupName, introduce, rules, uid)
     }
+
+    override suspend fun isDuplicatedGroupName(groupName: String): Boolean {
+        return groupDataSource.isDuplicatedGroupName(groupName)
+    }
 }

--- a/data/src/main/java/com/whyranoid/data/groupnotification/GroupNotificationDataSource.kt
+++ b/data/src/main/java/com/whyranoid/data/groupnotification/GroupNotificationDataSource.kt
@@ -99,10 +99,10 @@ class GroupNotificationDataSource @Inject constructor(
                                             )
                                         )
                                     }
+                                    trySend(finishNotificationList)
                                 }
                         }
                     }
-                    trySend(finishNotificationList)
                 }
 
             awaitClose()

--- a/data/src/main/java/com/whyranoid/data/model/GroupNotificationResponse.kt
+++ b/data/src/main/java/com/whyranoid/data/model/GroupNotificationResponse.kt
@@ -1,7 +1,5 @@
 package com.whyranoid.data.model
 
-import com.whyranoid.domain.model.FinishNotification
-import com.whyranoid.domain.model.RunningHistory
 import com.whyranoid.domain.model.StartNotification
 
 sealed interface GroupNotificationResponse {
@@ -18,29 +16,11 @@ data class StartNotificationResponse(
 data class FinishNotificationResponse(
     override val type: String = "",
     override val uid: String = "",
-    val finishedAt: Long = 0L,
-    val historyId: String = "",
-    val pace: Double = 0.0,
-    val startedAt: Long = 0L,
-    val totalDistance: Double = 0.0,
-    val totalRunningTime: Int = 0
+    val historyId: String = ""
 ) : GroupNotificationResponse
 
 fun StartNotificationResponse.toStartNotification() =
     StartNotification(
         uid = this.uid,
         startedAt = this.startedAt
-    )
-
-fun FinishNotificationResponse.toFinishNotification() =
-    FinishNotification(
-        uid = this.uid,
-        runningHistory = RunningHistory(
-            historyId = this.historyId,
-            startedAt = this.startedAt,
-            finishedAt = this.finishedAt,
-            totalRunningTime = this.totalRunningTime,
-            pace = this.pace,
-            totalDistance = this.totalDistance
-        )
     )

--- a/domain/src/main/java/com/whyranoid/domain/model/RunningHistory.kt
+++ b/domain/src/main/java/com/whyranoid/domain/model/RunningHistory.kt
@@ -1,10 +1,10 @@
 package com.whyranoid.domain.model
 
 data class RunningHistory(
-    val historyId: String,
-    val startedAt: Long,
-    val finishedAt: Long,
-    val totalRunningTime: Int,
-    val pace: Double,
-    val totalDistance: Double
+    val historyId: String = "",
+    val startedAt: Long = 0L,
+    val finishedAt: Long = 0L,
+    val totalRunningTime: Int = 0,
+    val pace: Double = 0.0,
+    val totalDistance: Double = 0.0
 )

--- a/domain/src/main/java/com/whyranoid/domain/repository/GroupRepository.kt
+++ b/domain/src/main/java/com/whyranoid/domain/repository/GroupRepository.kt
@@ -40,4 +40,6 @@ interface GroupRepository {
         rules: List<String>,
         uid: String
     ): Boolean
+
+    suspend fun isDuplicatedGroupName(groupName: String): Boolean
 }

--- a/domain/src/main/java/com/whyranoid/domain/usecase/CheckIsDuplicatedGroupNameUseCase.kt
+++ b/domain/src/main/java/com/whyranoid/domain/usecase/CheckIsDuplicatedGroupNameUseCase.kt
@@ -1,0 +1,13 @@
+package com.whyranoid.domain.usecase
+
+import com.whyranoid.domain.repository.GroupRepository
+import javax.inject.Inject
+
+class CheckIsDuplicatedGroupNameUseCase @Inject constructor(
+    private val groupRepository: GroupRepository
+) {
+
+    suspend operator fun invoke(groupName: String): Boolean {
+        return groupRepository.isDuplicatedGroupName(groupName)
+    }
+}

--- a/presentation/src/main/java/com/whyranoid/presentation/community/group/create/CreateGroupFragment.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/community/group/create/CreateGroupFragment.kt
@@ -34,12 +34,6 @@ internal class CreateGroupFragment :
                 handleEvent(event)
             }
         }
-
-        viewLifecycleOwner.repeatWhenUiStarted {
-            viewModel.rules.collect {
-                println("테스트 $it")
-            }
-        }
     }
 
     private fun handleEvent(event: Event) {
@@ -58,6 +52,22 @@ internal class CreateGroupFragment :
                         getString(R.string.text_create_group_fail),
                         Snackbar.LENGTH_SHORT
                     ).show()
+                }
+            }
+            is Event.DuplicateCheckButtonClick -> {
+                if (event.isDuplicatedGroupName) {
+                    Snackbar.make(
+                        binding.root,
+                        getString(R.string.text_duplicated_group_name),
+                        Snackbar.LENGTH_SHORT
+                    ).show()
+                } else {
+                    Snackbar.make(
+                        binding.root,
+                        getString(R.string.text_un_duplicated_group_name),
+                        Snackbar.LENGTH_SHORT
+                    ).show()
+                    binding.etGroupName.isEnabled = false
                 }
             }
             is Event.WarningButtonClick -> {
@@ -106,7 +116,7 @@ internal class CreateGroupFragment :
         }
 
         viewLifecycleOwner.repeatWhenUiStarted {
-            viewModel.isButtonEnable.collect { isEnable ->
+            viewModel.isGroupCreateButtonEnable.collect { isEnable ->
                 if (isEnable) {
                     binding.topAppBar.menu.setGroupVisible(R.id.ready_to_create, true)
                     binding.topAppBar.menu.setGroupVisible(R.id.not_ready_to_create, false)

--- a/presentation/src/main/java/com/whyranoid/presentation/community/group/create/Event.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/community/group/create/Event.kt
@@ -4,4 +4,5 @@ sealed class Event {
     data class CreateGroupButtonClick(val isSuccess: Boolean = true) : Event()
     object WarningButtonClick : Event()
     object AddRuleButtonClick : Event()
+    data class DuplicateCheckButtonClick(val isDuplicatedGroupName: Boolean = false) : Event()
 }

--- a/presentation/src/main/java/com/whyranoid/presentation/community/group/edit/EditGroupFragment.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/community/group/edit/EditGroupFragment.kt
@@ -51,6 +51,22 @@ internal class EditGroupFragment :
                     ).show()
                 }
             }
+            is Event.DuplicateCheckButtonClick -> {
+                if (event.isDuplicatedGroupName) {
+                    Snackbar.make(
+                        binding.root,
+                        getString(R.string.text_duplicated_group_name),
+                        Snackbar.LENGTH_SHORT
+                    ).show()
+                } else {
+                    Snackbar.make(
+                        binding.root,
+                        getString(R.string.text_un_duplicated_group_name),
+                        Snackbar.LENGTH_SHORT
+                    ).show()
+                    binding.etGroupName.isEnabled = false
+                }
+            }
             is Event.WarningButtonClick -> {
                 Snackbar.make(
                     binding.root,
@@ -69,7 +85,7 @@ internal class EditGroupFragment :
         }
 
         viewLifecycleOwner.repeatWhenUiStarted {
-            viewModel.isButtonEnable.collect { isEnable ->
+            viewModel.isGroupCreateButtonEnable.collect { isEnable ->
                 if (isEnable) {
                     binding.topAppBar.menu.setGroupVisible(R.id.ready_to_create, true)
                     binding.topAppBar.menu.setGroupVisible(R.id.not_ready_to_create, false)

--- a/presentation/src/main/java/com/whyranoid/presentation/community/group/edit/Event.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/community/group/edit/Event.kt
@@ -5,4 +5,5 @@ sealed class Event {
     data class EditGroupButtonClick(val isSuccess: Boolean = true) : Event()
     object WarningButtonClick : Event()
     object AddRuleButtonClick : Event()
+    data class DuplicateCheckButtonClick(val isDuplicatedGroupName: Boolean = false) : Event()
 }

--- a/presentation/src/main/res/layout/fragment_create_group.xml
+++ b/presentation/src/main/res/layout/fragment_create_group.xml
@@ -58,7 +58,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_margin="16dp"
-            android:enabled="@{viewModel.isButtonEnable()}"
+            android:enabled="@{viewModel.isDoubleCheckButtonEnable()}"
             android:onClick="@{() -> viewModel.onDuplicateCheckButtonClicked()}"
             android:text="@string/text_duplicate_check"
             app:layout_constraintBottom_toTopOf="@id/time_and_date_picker"

--- a/presentation/src/main/res/layout/fragment_edit_group.xml
+++ b/presentation/src/main/res/layout/fragment_edit_group.xml
@@ -59,7 +59,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_margin="16dp"
-            android:enabled="@{viewModel.isButtonEnable()}"
+            android:enabled="@{viewModel.isDoubleCheckButtonEnable()}"
             android:onClick="@{() -> viewModel.onDuplicateCheckButtonClicked()}"
             android:text="@string/text_duplicate_check"
             app:layout_constraintBottom_toTopOf="@id/time_and_date_picker"

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -87,5 +87,7 @@
     <string name="running_channel_name">활동 추적</string>
     <string name="running_channel_description">달리기 활동을 추적하는 알림 채널입니다.</string>
     <string name="text_join_group">그룹 가입하기</string>
+    <string name="text_duplicated_group_name">중복된 그룹 이름입니다. 변경해주세요!</string>
+    <string name="text_un_duplicated_group_name">사용 가능한 그룹 이름입니다!</string>
 
 </resources>


### PR DESCRIPTION
## 😎 작업 내용
- 그룹 생성 및 수정 시 그룹 이름이 중복이면 불가능하도록 변경
  - 중복이 아니게되면 EditText의 enabled속성이 false로 바뀌어 수정을 방지! 

## 🧐 변경된 내용
- 기존에는 Firebase에 저장된 Finish 알림이 RunningHistory의 필드들을 모두 가져야했는데, historyId만 가지고 RunningHistory 컬렉션은 별도로 관리하도록 변경
- 게시글을 불러올 때 updatedAt을 기준으로 내림차순 정렬해서 보여주도록 변경

## 🥳 동작 화면

- 중복이면 그룹 생성 메뉴가 활성화되지 않음!
![duplicatedCheck](https://user-images.githubusercontent.com/90144041/204769272-96d619f7-48d5-4fc0-913b-51003fa1d0d2.gif)


## 🤯 이슈 번호
- 이슈 없음
