### PR TITLE
인증 글 불러오는 기능 추가

### DIFF
--- a/data/src/main/java/com/whyranoid/data/Post/PostDataSource.kt
+++ b/data/src/main/java/com/whyranoid/data/Post/PostDataSource.kt
@@ -3,6 +3,8 @@ package com.whyranoid.data.Post
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.Query
 import com.whyranoid.data.constant.CollectionId
+import com.whyranoid.data.constant.FieldId.RUNNING_HISTORY_ID
+import com.whyranoid.data.constant.FieldId.UPDATED_AT
 import com.whyranoid.data.model.GroupInfoResponse
 import com.whyranoid.data.model.RecruitPostResponse
 import com.whyranoid.data.model.RunningPostResponse
@@ -30,12 +32,12 @@ class PostDataSource @Inject constructor(
     fun getAllPostFlow(): Flow<List<Post>> =
         callbackFlow {
             db.collection(CollectionId.POST_COLLECTION)
-                .orderBy("updatedAt", Query.Direction.DESCENDING)
+                .orderBy(UPDATED_AT, Query.Direction.DESCENDING)
                 .addSnapshotListener { snapshot, _ ->
                     val postList = mutableListOf<Post>()
                     snapshot?.forEach { docuemnt ->
 
-                        if (docuemnt["runningHistoryId"] != null) {
+                        if (docuemnt[RUNNING_HISTORY_ID] != null) {
                             docuemnt.toObject(RunningPostResponse::class.java).let { postResponse ->
                                 db.collection(CollectionId.USERS_COLLECTION)
                                     .document(postResponse.authorId)

--- a/data/src/main/java/com/whyranoid/data/Post/PostDataSource.kt
+++ b/data/src/main/java/com/whyranoid/data/Post/PostDataSource.kt
@@ -5,11 +5,14 @@ import com.google.firebase.firestore.Query
 import com.whyranoid.data.constant.CollectionId
 import com.whyranoid.data.model.GroupInfoResponse
 import com.whyranoid.data.model.RecruitPostResponse
+import com.whyranoid.data.model.RunningPostResponse
 import com.whyranoid.data.model.UserResponse
 import com.whyranoid.data.model.toGroupInfo
 import com.whyranoid.data.model.toUser
 import com.whyranoid.domain.model.Post
 import com.whyranoid.domain.model.RecruitPost
+import com.whyranoid.domain.model.RunningHistory
+import com.whyranoid.domain.model.RunningPost
 import com.whyranoid.domain.model.toRule
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
@@ -23,52 +26,92 @@ class PostDataSource @Inject constructor(
     private val db: FirebaseFirestore
 ) {
 
-    //  TODO : 타입을 확인하고 캐스팅하는 부분 필요
+    //  TODO : 조금 더 간결하게 처리 필요.
     fun getAllPostFlow(): Flow<List<Post>> =
         callbackFlow {
             db.collection(CollectionId.POST_COLLECTION)
                 .orderBy("updatedAt", Query.Direction.DESCENDING)
                 .addSnapshotListener { snapshot, _ ->
-                    val recruitPostList = mutableListOf<Post>()
+                    val postList = mutableListOf<Post>()
                     snapshot?.forEach { docuemnt ->
-                        docuemnt.toObject(RecruitPostResponse::class.java).let { postResponse ->
 
-                            db.collection(CollectionId.USERS_COLLECTION)
-                                .document(postResponse.authorId)
-                                .get()
-                                .addOnSuccessListener { authorDocument ->
-                                    val authorResponse =
-                                        authorDocument?.toObject(UserResponse::class.java)
+                        if (docuemnt["runningHistoryId"] != null) {
+                            docuemnt.toObject(RunningPostResponse::class.java).let { postResponse ->
+                                db.collection(CollectionId.USERS_COLLECTION)
+                                    .document(postResponse.authorId)
+                                    .get()
+                                    .addOnSuccessListener { authorDocument ->
+                                        val authorResponse =
+                                            authorDocument?.toObject(UserResponse::class.java)
 
-                                    authorResponse?.let {
-                                        db.collection(CollectionId.GROUPS_COLLECTION)
-                                            .document(postResponse.groupId)
-                                            .get()
-                                            .addOnSuccessListener { groupDocument ->
-                                                val groupInfoResponse =
-                                                    groupDocument.toObject(GroupInfoResponse::class.java)
-
-                                                groupInfoResponse?.let { groupInfoResponse ->
-                                                    val author = authorResponse.toUser()
-                                                    recruitPostList.add(
-                                                        RecruitPost(
-                                                            postId = postResponse.postId,
-                                                            author = author,
-                                                            updatedAt = postResponse.updatedAt,
-                                                            groupInfo = groupInfoResponse
-                                                                .toGroupInfo(
-                                                                    author,
-                                                                    rules = groupInfoResponse.rules.map {
-                                                                        it.toRule()
-                                                                    }
-                                                                )
+                                        authorResponse?.let {
+                                            db.collection(CollectionId.RUNNING_HISTORY_COLLECTION)
+                                                .document(postResponse.runningHistoryId)
+                                                .get()
+                                                .addOnSuccessListener { runningHistoryDocument ->
+                                                    val runningHistoryResponse =
+                                                        runningHistoryDocument.toObject(
+                                                            RunningHistory::class.java
                                                         )
-                                                    )
-                                                    trySend(recruitPostList)
+
+                                                    runningHistoryResponse?.let {
+                                                        val author = authorResponse.toUser()
+
+                                                        postList.add(
+                                                            RunningPost(
+                                                                postId = postResponse.postId,
+                                                                author = author,
+                                                                updatedAt = postResponse.updatedAt,
+                                                                runningHistory = it,
+                                                                likeCount = 0,
+                                                                content = postResponse.content
+                                                            )
+                                                        )
+                                                    }
                                                 }
-                                            }
+                                        }
                                     }
-                                }
+                            }
+                        } else {
+                            docuemnt.toObject(RecruitPostResponse::class.java).let { postResponse ->
+
+                                db.collection(CollectionId.USERS_COLLECTION)
+                                    .document(postResponse.authorId)
+                                    .get()
+                                    .addOnSuccessListener { authorDocument ->
+                                        val authorResponse =
+                                            authorDocument?.toObject(UserResponse::class.java)
+
+                                        authorResponse?.let {
+                                            db.collection(CollectionId.GROUPS_COLLECTION)
+                                                .document(postResponse.groupId)
+                                                .get()
+                                                .addOnSuccessListener { groupDocument ->
+                                                    val groupInfoResponse =
+                                                        groupDocument.toObject(GroupInfoResponse::class.java)
+
+                                                    groupInfoResponse?.let { groupInfoResponse ->
+                                                        val author = authorResponse.toUser()
+                                                        postList.add(
+                                                            RecruitPost(
+                                                                postId = postResponse.postId,
+                                                                author = author,
+                                                                updatedAt = postResponse.updatedAt,
+                                                                groupInfo = groupInfoResponse
+                                                                    .toGroupInfo(
+                                                                        author,
+                                                                        rules = groupInfoResponse.rules.map {
+                                                                            it.toRule()
+                                                                        }
+                                                                    )
+                                                            )
+                                                        )
+                                                        trySend(postList)
+                                                    }
+                                                }
+                                        }
+                                    }
+                            }
                         }
                     }
                 }

--- a/data/src/main/java/com/whyranoid/data/constant/FieldId.kt
+++ b/data/src/main/java/com/whyranoid/data/constant/FieldId.kt
@@ -8,4 +8,6 @@ object FieldId {
     const val GROUP_INTRODUCE = "introduce"
     const val RULES = "rules"
     const val JOINED_GROUP_LIST = "joinedGroupList"
+    const val UPDATED_AT = "updatedAt"
+    const val RUNNING_HISTORY_ID = "runningHistoryId"
 }

--- a/data/src/main/java/com/whyranoid/data/model/PostResponse.kt
+++ b/data/src/main/java/com/whyranoid/data/model/PostResponse.kt
@@ -12,3 +12,11 @@ data class RecruitPostResponse(
     override val postId: String = "",
     override val updatedAt: Long = 0L
 ) : PostResponse
+
+data class RunningPostResponse(
+    override val postId: String = "",
+    override val authorId: String = "",
+    override val updatedAt: Long = 0L,
+    val runningHistoryId: String = "",
+    val content: String = ""
+) : PostResponse

--- a/presentation/src/main/java/com/whyranoid/presentation/community/PostAdapter.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/community/PostAdapter.kt
@@ -3,15 +3,18 @@ package com.whyranoid.presentation.community
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.databinding.ViewDataBinding
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.whyranoid.domain.model.Post
 import com.whyranoid.domain.model.RecruitPost
+import com.whyranoid.domain.model.RunningPost
 import com.whyranoid.presentation.databinding.ItemRecruitPostBinding
+import com.whyranoid.presentation.databinding.ItemRunningPostBinding
 
 class PostAdapter(private val myUid: String) :
-    ListAdapter<Post, PostAdapter.RecruitPostViewHolder>(diffUtil) {
+    ListAdapter<Post, PostAdapter.PostViewHolder>(diffUtil) {
 
     companion object {
         val diffUtil = object : DiffUtil.ItemCallback<Post>() {
@@ -21,6 +24,14 @@ class PostAdapter(private val myUid: String) :
             override fun areContentsTheSame(oldItem: Post, newItem: Post) =
                 oldItem == newItem
         }
+
+        const val RECRUIT_POST_TYPE = 0
+        const val RUNNING_POST_TYPE = 1
+    }
+
+    abstract class PostViewHolder(binding: ViewDataBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+        abstract fun bind(post: Post)
     }
 
     inner class RecruitPostViewHolder(
@@ -30,12 +41,11 @@ class PostAdapter(private val myUid: String) :
             parent,
             false
         )
-    ) : RecyclerView.ViewHolder(binding.root) {
-        fun bind(post: Post) {
+    ) : PostViewHolder(binding) {
+        override fun bind(post: Post) {
             if (post is RecruitPost) {
                 binding.recruitPost = post
                 if (myUid == post.author.uid) {
-                    println("테스트 $myUid ${post.author.uid}")
                     binding.btnJoinGroup.visibility = View.GONE
                 } else {
                     binding.btnJoinGroup.visibility = View.VISIBLE
@@ -44,11 +54,36 @@ class PostAdapter(private val myUid: String) :
         }
     }
 
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecruitPostViewHolder {
-        return RecruitPostViewHolder(parent)
+    inner class RunningHistoryPostViewHolder(
+        parent: ViewGroup,
+        private val binding: ItemRunningPostBinding = ItemRunningPostBinding.inflate(
+            LayoutInflater.from(parent.context),
+            parent,
+            false
+        )
+    ) : PostViewHolder(binding) {
+        override fun bind(post: Post) {
+            if (post is RunningPost) {
+                binding.runningPost = post
+            }
+        }
     }
 
-    override fun onBindViewHolder(holder: RecruitPostViewHolder, position: Int) {
+    override fun getItemViewType(position: Int): Int {
+        return when (getItem(position)) {
+            is RecruitPost -> RECRUIT_POST_TYPE
+            else -> RUNNING_POST_TYPE
+        }
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): PostViewHolder {
+        return when (viewType) {
+            RECRUIT_POST_TYPE -> RecruitPostViewHolder(parent)
+            else -> RunningHistoryPostViewHolder(parent)
+        }
+    }
+
+    override fun onBindViewHolder(holder: PostViewHolder, position: Int) {
         holder.bind(getItem(position))
     }
 }

--- a/presentation/src/main/java/com/whyranoid/presentation/community/group/detail/GroupDetailViewModel.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/community/group/detail/GroupDetailViewModel.kt
@@ -54,7 +54,6 @@ class GroupDetailViewModel @Inject constructor(
 
         // TODO : uid를 DataStore에서 가져오도록 변경
         getGroupInfoUseCase("hsjeon", groupId).onEach { groupInfo ->
-            println("테스트 $groupInfo")
             _groupInfo.value = groupInfo.toGroupInfoUiModel()
         }.launchIn(viewModelScope)
 

--- a/presentation/src/main/java/com/whyranoid/presentation/util/BindingAdapters.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/util/BindingAdapters.kt
@@ -48,3 +48,9 @@ fun TextView.finishLongToDate(long: Long) {
     val formatter = SimpleDateFormat("yyyy.MM.dd / HH 시 mm 분 운동 종료", Locale.KOREA)
     text = formatter.format(Date(long))
 }
+
+@BindingAdapter("LongToTime")
+fun TextView.longToTime(long: Long) {
+    val formatter = SimpleDateFormat("HH : mm", Locale.KOREA)
+    text = formatter.format(Date(long))
+}

--- a/presentation/src/main/res/layout/item_recruit_post.xml
+++ b/presentation/src/main/res/layout/item_recruit_post.xml
@@ -31,6 +31,7 @@
             android:text="@{recruitPost.author.name}"
             app:layout_constraintStart_toEndOf="@id/iv_leader_profile"
             app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="@id/iv_leader_profile"
             tools:text="수피치" />
 
         <TextView
@@ -44,7 +45,7 @@
             android:text="@{recruitPost.groupInfo.name}"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/tv_leader_name"
+            app:layout_constraintTop_toBottomOf="@id/iv_leader_profile"
             tools:text="수피치와 함께 춤을\n출까 말까" />
 
         <TextView

--- a/presentation/src/main/res/layout/item_running_post.xml
+++ b/presentation/src/main/res/layout/item_running_post.xml
@@ -1,0 +1,193 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="runningPost"
+            type="com.whyranoid.domain.model.RunningPost" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <ImageView
+            android:id="@+id/iv_leader_profile"
+            loadImage="@{runningPost.author.profileUrl}"
+            android:layout_width="50dp"
+            android:layout_height="50dp"
+            android:layout_margin="16dp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/tv_leader_name"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_margin="16dp"
+            android:text="@{runningPost.author.name}"
+            app:layout_constraintBottom_toBottomOf="@id/iv_leader_profile"
+            app:layout_constraintStart_toEndOf="@id/iv_leader_profile"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="수피치" />
+
+        <TextView
+            android:id="@+id/tv_running_history_date"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="16dp"
+            android:text="@{runningPost.runningHistory.historyId}"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/iv_leader_profile"
+            tools:text="2022/09/11" />
+
+        <TextView
+            android:id="@+id/tv_label_total_running_time"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="20dp"
+            android:text="@string/running_history_label_total_running_time"
+            app:layout_constraintBottom_toBottomOf="@id/tv_running_history_date"
+            app:layout_constraintEnd_toStartOf="@id/tv_total_running_time"
+            app:layout_constraintTop_toTopOf="@id/tv_running_history_date" />
+
+        <TextView
+            android:id="@+id/tv_total_running_time"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@{Integer.toString(runningPost.runningHistory.totalRunningTime)}"
+            app:layout_constraintBottom_toBottomOf="@id/tv_label_total_running_time"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="@id/tv_label_total_running_time"
+            tools:text="2시간 22분" />
+
+        <View
+            android:id="@+id/view_vertical_partition_line"
+            android:layout_width="1dp"
+            android:layout_height="100dp"
+            android:layout_marginTop="20dp"
+            android:layout_marginBottom="20dp"
+            android:background="@color/black"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_label_total_running_time" />
+
+        <View
+            android:id="@+id/view_horizontal_partition_line"
+            android:layout_width="0dp"
+            android:layout_height="1dp"
+            android:layout_marginTop="20dp"
+            android:layout_marginBottom="20dp"
+            android:background="@color/black"
+            app:layout_constraintBottom_toBottomOf="@id/view_vertical_partition_line"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="@id/view_vertical_partition_line" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="16dp"
+            android:text="@string/running_history_label_start_running_time"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_running_history_date" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="50dp"
+            android:layout_marginBottom="20dp"
+            app:LongToTime="@{runningPost.runningHistory.startedAt}"
+            app:layout_constraintBottom_toBottomOf="@id/view_horizontal_partition_line"
+            app:layout_constraintEnd_toStartOf="@id/view_vertical_partition_line"
+            tools:text="17:00" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="12dp"
+            android:layout_marginTop="16dp"
+            android:text="@string/running_history_label_finish_running_time"
+            app:layout_constraintStart_toStartOf="@id/view_vertical_partition_line"
+            app:layout_constraintTop_toBottomOf="@id/tv_running_history_date" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="50dp"
+            android:layout_marginBottom="20dp"
+            app:LongToTime="@{runningPost.runningHistory.finishedAt}"
+            app:layout_constraintBottom_toBottomOf="@id/view_horizontal_partition_line"
+            app:layout_constraintEnd_toEndOf="parent"
+            tools:text="19:22" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="12dp"
+            android:text="@string/running_history_label_running_distance"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/view_horizontal_partition_line" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:layout_marginEnd="50dp"
+            android:text="@{Double.toString(runningPost.runningHistory.totalDistance)}"
+            app:layout_constraintEnd_toStartOf="@id/view_vertical_partition_line"
+            app:layout_constraintTop_toBottomOf="@id/view_horizontal_partition_line"
+            tools:text="11.7km" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="12dp"
+            android:layout_marginTop="12dp"
+            android:text="@string/running_history_label_running_pace"
+            app:layout_constraintStart_toStartOf="@id/view_vertical_partition_line"
+            app:layout_constraintTop_toBottomOf="@id/view_horizontal_partition_line" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:layout_marginEnd="50dp"
+            android:text="@{Double.toString(runningPost.runningHistory.pace)}"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/view_horizontal_partition_line"
+            tools:text="6.3km/h" />
+
+        <TextView
+            android:id="@+id/tv_like_cnt"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="16dp"
+            android:layout_marginTop="8dp"
+            android:text="@{@string/text_like_count(runningPost.likeCount)}"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/view_vertical_partition_line"
+            tools:text="좋아요 0개" />
+
+        <TextView
+            android:id="@+id/tv_content"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="16dp"
+            android:layout_marginTop="8dp"
+            android:text="@{runningPost.content}"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_like_cnt"
+            tools:text="컨\n투더\n텐\n투더\n츠" />
+
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -89,5 +89,6 @@
     <string name="text_join_group">그룹 가입하기</string>
     <string name="text_duplicated_group_name">중복된 그룹 이름입니다. 변경해주세요!</string>
     <string name="text_un_duplicated_group_name">사용 가능한 그룹 이름입니다!</string>
+    <string name="text_like_count">좋아요 %d개</string>
 
 </resources>


### PR DESCRIPTION
## 😎 작업 내용
- 인증 글 불러오는 기능 추가

## 🧐 변경된 내용
- 기존에 게시글 페이지에서는 홍보 글만 불러왔는데 홍보 글, 인증 글 모두 불러오도록 변경

## 🥳 동작 화면
<img width="418" alt="Screenshot 2022-11-30 at 10 42 24 PM" src="https://user-images.githubusercontent.com/90144041/204811648-ad139097-c2b5-431f-b15a-83cc3962762d.png">

## 🤯 이슈 번호
- 이슈 없음

##  🥲 비고
- 레이아웃은 좀 이쁘게 변경할 필요가 있음.