### PR TITLE
러닝 히스토리 아이템 UI 개선, 러닝 시작/종료 시 로딩 UI 추가

### DIFF
--- a/presentation/src/main/java/com/whyranoid/presentation/running/RunningActivity.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/running/RunningActivity.kt
@@ -130,12 +130,13 @@ internal class RunningActivity :
     private fun observeState() {
         repeatWhenUiStarted {
             viewModel.runningState.collect { runningState ->
-                with(runningState.runningData) {
-                    binding.tvStartTime.text = Date(startTime).dateToString("hh:mm")
-                    binding.tvRunningTime.text =
-                        String.format("%d:%02d", runningTime / 60, runningTime % 60)
-                    binding.tvTotalDistance.text = String.format("%.4f m", totalDistance)
-                    binding.tvPace.text = String.format("%.4f km/h", pace * 3.6)
+                when (runningState) {
+                    is RunningState.NotRunning -> {
+                    }
+                    is RunningState.Running,
+                    is RunningState.Paused -> {
+                        handleUpdateState(runningState.runningData)
+                    }
                 }
             }
         }
@@ -206,6 +207,16 @@ internal class RunningActivity :
                     paths[index].map = naverMap
                 }
             }
+        }
+    }
+
+    private fun handleUpdateState(runningData: RunningData) {
+        with(runningData) {
+            binding.tvStartTime.text = Date(startTime).dateToString("hh:mm")
+            binding.tvRunningTime.text =
+                String.format("%d:%02d", runningTime / 60, runningTime % 60)
+            binding.tvTotalDistance.text = String.format("%.4f m", totalDistance)
+            binding.tvPace.text = String.format("%.4f km/h", pace * 3.6)
         }
     }
 

--- a/presentation/src/main/java/com/whyranoid/presentation/running/RunningActivity.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/running/RunningActivity.kt
@@ -210,7 +210,10 @@ internal class RunningActivity :
     }
 
     private fun handleRunningFinishSuccessState(runningFinishData: RunningFinishData) {
-        setResult(RESULT_OK, Intent().putExtra(RunningViewModel.RUNNING_FINISH_DATA_KEY, runningFinishData))
+        setResult(
+            RESULT_OK,
+            Intent().putExtra(RunningViewModel.RUNNING_FINISH_DATA_KEY, runningFinishData)
+        )
         finish()
     }
 

--- a/presentation/src/main/java/com/whyranoid/presentation/util/BindingAdapters.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/util/BindingAdapters.kt
@@ -49,8 +49,8 @@ fun TextView.finishLongToDate(long: Long) {
     text = formatter.format(Date(long))
 }
 
-@BindingAdapter("LongToTime")
+@BindingAdapter("longToTime")
 fun TextView.longToTime(long: Long) {
-    val formatter = SimpleDateFormat("HH : mm", Locale.KOREA)
+    val formatter = SimpleDateFormat("HH:mm", Locale.getDefault())
     text = formatter.format(Date(long))
 }

--- a/presentation/src/main/res/drawable/background_rounded.xml
+++ b/presentation/src/main/res/drawable/background_rounded.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="?attr/colorPrimary" />
+    <corners android:radius="6dp" />
+
+</shape>

--- a/presentation/src/main/res/layout/activity_running.xml
+++ b/presentation/src/main/res/layout/activity_running.xml
@@ -24,8 +24,8 @@
             android:id="@+id/btn_map_location"
             android:layout_width="50dp"
             android:layout_height="50dp"
-            android:text="@string/running_map_location_button"
             android:onClick="@{() -> vm.onTrackingButtonClicked()}"
+            android:text="@string/running_map_location_button"
             app:layout_constraintBottom_toTopOf="@id/panel_running_data"
             app:layout_constraintRight_toRightOf="@id/panel_running_data" />
 
@@ -37,9 +37,9 @@
             android:layout_margin="12dp"
             android:background="@color/white"
             android:clickable="false"
+            android:elevation="@dimen/cardview_default_elevation"
             android:paddingHorizontal="12dp"
             android:paddingVertical="8dp"
-            android:elevation="@dimen/cardview_default_elevation"
             app:layout_constraintBottom_toTopOf="@+id/btn_pause_or_resume"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent">
@@ -142,7 +142,6 @@
                 tools:text="6.3km/h" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
-
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/btn_pause_or_resume"

--- a/presentation/src/main/res/layout/activity_running.xml
+++ b/presentation/src/main/res/layout/activity_running.xml
@@ -5,6 +5,10 @@
 
     <data>
 
+        <import type="com.whyranoid.presentation.running.RunningState" />
+
+        <import type="android.view.View" />
+
         <variable
             name="vm"
             type="com.whyranoid.presentation.running.RunningViewModel" />
@@ -164,6 +168,27 @@
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toEndOf="@id/btn_pause_or_resume" />
+
+        <FrameLayout
+            android:id="@+id/frame_progress_running"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:background="@color/black"
+            android:alpha="0.8"
+            android:translationZ="@{vm.runningState instanceof RunningState.NotRunning ? 10f : 0f }"
+            android:visibility="@{vm.runningState instanceof RunningState.NotRunning ? View.VISIBLE : View.GONE }">
+
+            <com.google.android.material.progressindicator.CircularProgressIndicator
+                android:id="@+id/progressindicator_running"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:contentDescription="@string/running_start_progress_description"
+                android:indeterminate="true"
+                android:visibility="@{vm.runningState instanceof RunningState.NotRunning ? View.VISIBLE : View.GONE }"
+                app:indicatorColor="?attr/colorOnPrimary" />
+
+        </FrameLayout>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/presentation/src/main/res/layout/item_running_history.xml
+++ b/presentation/src/main/res/layout/item_running_history.xml
@@ -4,6 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <data>
+
         <variable
             name="runningHistory"
             type="com.whyranoid.presentation.model.RunningHistoryUiModel" />
@@ -12,15 +13,34 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:padding="12dp">
+        android:layout_margin="2dp"
+        android:background="@drawable/background_rounded"
+        android:backgroundTint="@color/mogakrun_secondary"
+        android:elevation="@dimen/cardview_default_elevation">
+
+        <View
+            android:id="@+id/view_running_history_body"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:background="@drawable/background_rounded"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_running_history_date" />
 
         <TextView
             android:id="@+id/tv_running_history_date"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:maxLines="1"
+            android:text="@{Long.toString(runningHistory.date)}"
+            android:textAppearance="@style/MoGakRunText.Regular.Small"
+            android:textColor="?attr/colorOnSecondary"
+            app:layout_constraintEnd_toEndOf="@id/view_vertical_partition_line"
+            app:layout_constraintHorizontal_bias="0.1"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            android:text="@{Long.toString(runningHistory.date)}"
             tools:text="2022/09/11" />
 
         <TextView
@@ -29,8 +49,10 @@
             android:layout_height="wrap_content"
             android:layout_marginEnd="20dp"
             android:text="@string/running_history_label_total_running_time"
+            android:textAppearance="@style/MoGakRunText.Light.Small"
             app:layout_constraintBottom_toBottomOf="@id/tv_running_history_date"
             app:layout_constraintEnd_toStartOf="@id/tv_total_running_time"
+            app:layout_constraintStart_toStartOf="@id/view_vertical_partition_line"
             app:layout_constraintTop_toTopOf="@id/tv_running_history_date" />
 
         <TextView
@@ -38,108 +60,136 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@{Integer.toString(runningHistory.totalRunningTime)}"
+            android:textAppearance="@style/MoGakRunText.Regular.Small"
             app:layout_constraintBottom_toBottomOf="@id/tv_label_total_running_time"
             app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/tv_label_total_running_time"
             app:layout_constraintTop_toTopOf="@id/tv_label_total_running_time"
             tools:text="2시간 22분" />
 
         <View
             android:id="@+id/view_vertical_partition_line"
             android:layout_width="1dp"
-            android:layout_height="100dp"
-            app:layout_constraintTop_toBottomOf="@id/tv_label_total_running_time"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
+            android:layout_height="0dp"
+            android:alpha="0.2"
+            android:background="?attr/colorOnSecondary"
             app:layout_constraintBottom_toBottomOf="parent"
-            android:layout_marginTop="20dp"
-            android:layout_marginBottom="20dp"
-            android:background="@color/black" />
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="@id/view_running_history_body" />
 
         <View
             android:id="@+id/view_horizontal_partition_line"
             android:layout_width="0dp"
             android:layout_height="1dp"
-            app:layout_constraintStart_toStartOf="parent"
+            android:alpha="0.2"
+            android:background="?attr/colorOnSecondary"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/tv_label_total_running_time"
-            app:layout_constraintBottom_toBottomOf="parent"
-            android:layout_marginTop="20dp"
-            android:layout_marginBottom="20dp"
-            android:background="@color/black" />
-
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/running_history_label_start_running_time"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/tv_running_history_date"
-            app:layout_constraintBottom_toTopOf="@id/view_horizontal_partition_line" />
+            app:layout_constraintTop_toBottomOf="@id/tv_start_time_value" />
 
         <TextView
+            android:id="@+id/tv_start_time_label"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            tools:text="17:00"
-            android:text="@{Long.toString(runningHistory.startedAt)}"
-            app:layout_constraintEnd_toStartOf="@id/view_vertical_partition_line"
-            app:layout_constraintBottom_toBottomOf="@id/view_horizontal_partition_line"
-            android:layout_marginEnd="50dp"
-            android:layout_marginBottom="20dp" />
-
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/running_history_label_finish_running_time"
-            android:layout_marginStart="12dp"
-            app:layout_constraintStart_toStartOf="@id/view_vertical_partition_line"
-            app:layout_constraintTop_toBottomOf="@id/tv_running_history_date"
-            app:layout_constraintBottom_toTopOf="@id/view_horizontal_partition_line" />
-
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            tools:text="19:22"
-            android:text="@{Long.toString(runningHistory.finishedAt)}"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintBottom_toBottomOf="@id/view_horizontal_partition_line"
-            android:layout_marginEnd="50dp"
-            android:layout_marginBottom="20dp" />
-
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/running_history_label_running_distance"
-            app:layout_constraintStart_toStartOf="parent"
+            android:layout_marginHorizontal="6dp"
             android:layout_marginTop="12dp"
+            android:text="@string/running_history_label_start_running_time"
+            android:textAppearance="@style/MoGakRunText.Light.Small"
+            app:layout_constraintEnd_toStartOf="@id/view_vertical_partition_line"
+            app:layout_constraintHorizontal_bias="0.0"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_running_history_date" />
+
+        <TextView
+            android:id="@+id/tv_start_time_value"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingTop="10dp"
+            android:paddingBottom="20dp"
+            android:text="@{Long.toString(runningHistory.startedAt)}"
+            android:textAppearance="@style/MoGakRunText.Regular.Medium"
+            app:layout_constraintEnd_toStartOf="@id/view_vertical_partition_line"
+            app:layout_constraintHorizontal_bias="0.6"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_start_time_label"
+            tools:text="17:00" />
+
+        <TextView
+            android:id="@+id/tv_end_time_label"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="12dp"
+            android:text="@string/running_history_label_finish_running_time"
+            android:textAppearance="@style/MoGakRunText.Light.Small"
+            app:layout_constraintStart_toStartOf="@id/view_vertical_partition_line"
+            app:layout_constraintTop_toTopOf="@id/tv_start_time_label" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="20dp"
+            android:paddingTop="10dp"
+            android:paddingBottom="20dp"
+            android:text="@{Long.toString(runningHistory.finishedAt)}"
+            android:textAppearance="@style/MoGakRunText.Regular.Medium"
+            app:layout_constraintEnd_toEndOf="@id/view_horizontal_partition_line"
+            app:layout_constraintHorizontal_bias="0.6"
+            app:layout_constraintStart_toEndOf="@id/view_vertical_partition_line"
+            app:layout_constraintTop_toBottomOf="@id/tv_end_time_label"
+            tools:text="19:22" />
+
+        <TextView
+            android:id="@+id/tv_total_distance_label"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="6dp"
+            android:layout_marginTop="12dp"
+            android:text="@string/running_history_label_running_distance"
+            android:textAppearance="@style/MoGakRunText.Light.Small"
+            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/view_horizontal_partition_line" />
 
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            tools:text="11.7km"
+            android:layout_marginTop="24dp"
+            android:paddingTop="10dp"
+            android:paddingBottom="20dp"
             android:text="@{Double.toString(runningHistory.totalDistance)}"
+            android:textAppearance="@style/MoGakRunText.Regular.Medium"
             app:layout_constraintEnd_toStartOf="@id/view_vertical_partition_line"
+            app:layout_constraintHorizontal_bias="0.6"
+            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/view_horizontal_partition_line"
-            android:layout_marginTop="24dp"
-            android:layout_marginEnd="50dp" />
+            tools:text="11.7km" />
 
         <TextView
+            android:id="@+id/tv_total_pace_label"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/running_history_label_running_pace"
-            app:layout_constraintTop_toBottomOf="@id/view_horizontal_partition_line"
-            app:layout_constraintStart_toStartOf="@id/view_vertical_partition_line"
+            android:layout_marginStart="12dp"
             android:layout_marginTop="12dp"
-            android:layout_marginStart="12dp" />
+            android:text="@string/running_history_label_running_pace"
+            android:textAppearance="@style/MoGakRunText.Light.Small"
+            app:layout_constraintStart_toStartOf="@id/view_vertical_partition_line"
+            app:layout_constraintTop_toBottomOf="@id/view_horizontal_partition_line" />
 
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            tools:text="6.3km/h"
-            android:text="@{Double.toString(runningHistory.pace)}"
-            app:layout_constraintTop_toBottomOf="@id/view_horizontal_partition_line"
-            app:layout_constraintEnd_toEndOf="parent"
             android:layout_marginTop="24dp"
-            android:layout_marginEnd="50dp" />
+            android:paddingTop="10dp"
+            android:paddingBottom="20dp"
+            android:text="@{Double.toString(runningHistory.pace)}"
+            android:textAppearance="@style/MoGakRunText.Regular.Medium"
+            app:layout_constraintEnd_toEndOf="@id/view_horizontal_partition_line"
+            app:layout_constraintHorizontal_bias="0.6"
+            app:layout_constraintStart_toEndOf="@id/view_vertical_partition_line"
+            app:layout_constraintTop_toBottomOf="@id/view_horizontal_partition_line"
+            tools:text="6.3km/h" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
+
+
 </layout>

--- a/presentation/src/main/res/layout/item_running_history.xml
+++ b/presentation/src/main/res/layout/item_running_history.xml
@@ -5,6 +5,8 @@
 
     <data>
 
+        <import type="com.whyranoid.presentation.util.ExtensionsKt" />
+
         <variable
             name="runningHistory"
             type="com.whyranoid.presentation.model.RunningHistoryUiModel" />
@@ -34,7 +36,7 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="4dp"
             android:maxLines="1"
-            android:text="@{Long.toString(runningHistory.date)}"
+            android:text="@{ExtensionsKt.toRunningDateString(runningHistory.date)}"
             android:textAppearance="@style/MoGakRunText.Regular.Small"
             android:textColor="?attr/colorOnSecondary"
             app:layout_constraintEnd_toEndOf="@id/view_vertical_partition_line"
@@ -59,7 +61,7 @@
             android:id="@+id/tv_total_running_time"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@{Integer.toString(runningHistory.totalRunningTime)}"
+            android:text="@{String.format(@string/running_history_value_total_running_time, runningHistory.totalRunningTime / 3600, runningHistory.totalRunningTime / 60)}"
             android:textAppearance="@style/MoGakRunText.Regular.Small"
             app:layout_constraintBottom_toBottomOf="@id/tv_label_total_running_time"
             app:layout_constraintEnd_toEndOf="parent"
@@ -103,11 +105,11 @@
 
         <TextView
             android:id="@+id/tv_start_time_value"
+            longToTime="@{runningHistory.startedAt}"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:paddingTop="10dp"
             android:paddingBottom="20dp"
-            android:text="@{Long.toString(runningHistory.startedAt)}"
             android:textAppearance="@style/MoGakRunText.Regular.Medium"
             app:layout_constraintEnd_toStartOf="@id/view_vertical_partition_line"
             app:layout_constraintHorizontal_bias="0.6"
@@ -126,12 +128,12 @@
             app:layout_constraintTop_toTopOf="@id/tv_start_time_label" />
 
         <TextView
+            longToTime="@{runningHistory.finishedAt}"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginBottom="20dp"
             android:paddingTop="10dp"
             android:paddingBottom="20dp"
-            android:text="@{Long.toString(runningHistory.finishedAt)}"
             android:textAppearance="@style/MoGakRunText.Regular.Medium"
             app:layout_constraintEnd_toEndOf="@id/view_horizontal_partition_line"
             app:layout_constraintHorizontal_bias="0.6"
@@ -156,7 +158,7 @@
             android:layout_marginTop="24dp"
             android:paddingTop="10dp"
             android:paddingBottom="20dp"
-            android:text="@{Double.toString(runningHistory.totalDistance)}"
+            android:text="@{runningHistory.totalDistance >= 1000 ? String.format(@string/running_history_value_running_distance_km, runningHistory.totalDistance / 1000) : String.format(@string/running_history_value_running_distance_m, runningHistory.totalDistance)}"
             android:textAppearance="@style/MoGakRunText.Regular.Medium"
             app:layout_constraintEnd_toStartOf="@id/view_vertical_partition_line"
             app:layout_constraintHorizontal_bias="0.6"
@@ -181,7 +183,7 @@
             android:layout_marginTop="24dp"
             android:paddingTop="10dp"
             android:paddingBottom="20dp"
-            android:text="@{Double.toString(runningHistory.pace)}"
+            android:text="@{String.format(@string/running_history_value_running_pace, runningHistory.pace)}"
             android:textAppearance="@style/MoGakRunText.Regular.Medium"
             app:layout_constraintEnd_toEndOf="@id/view_horizontal_partition_line"
             app:layout_constraintHorizontal_bias="0.6"

--- a/presentation/src/main/res/layout/item_running_post.xml
+++ b/presentation/src/main/res/layout/item_running_post.xml
@@ -102,7 +102,7 @@
             android:layout_height="wrap_content"
             android:layout_marginEnd="50dp"
             android:layout_marginBottom="20dp"
-            app:LongToTime="@{runningPost.runningHistory.startedAt}"
+            app:longToTime="@{runningPost.runningHistory.startedAt}"
             app:layout_constraintBottom_toBottomOf="@id/view_horizontal_partition_line"
             app:layout_constraintEnd_toStartOf="@id/view_vertical_partition_line"
             tools:text="17:00" />
@@ -121,7 +121,7 @@
             android:layout_height="wrap_content"
             android:layout_marginEnd="50dp"
             android:layout_marginBottom="20dp"
-            app:LongToTime="@{runningPost.runningHistory.finishedAt}"
+            app:longToTime="@{runningPost.runningHistory.finishedAt}"
             app:layout_constraintBottom_toBottomOf="@id/view_horizontal_partition_line"
             app:layout_constraintEnd_toEndOf="parent"
             tools:text="19:22" />

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -113,6 +113,7 @@
     <string name="running_channel_name">활동 추적</string>
     <string name="running_channel_description">달리기 활동을 추적하는 알림 채널입니다.</string>
     <string name="running_map_location_button">🎯</string>
+    <string name="running_start_progress_description">러닝 시작을 기다리고 있어요</string>
 
     <!--라닝 종료 화면-->
     <string name="running_finish_tool_bar">러닝 종료</string>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -38,6 +38,8 @@
     <string name="text_delete_post_fail">게시글 삭제에 실패하였습니다!</string>
     <string name="text_check_delete_post">해당 포스트를 삭제하시겠습니까?</string>
     <string name="text_delete">삭제</string>
+    <string name="text_join_group">그룹 가입하기</string>
+    <string name="text_like_count">좋아요 %d개</string>
 
     <!-- 마이런 탭 화면 -->
     <string name="my_run_tool_bar_menu_setting">설정</string>
@@ -63,6 +65,8 @@
     <string name="text_go_to_create_group">그룹 생성하러 가기</string>
     <string name="text_group_introduce">그룹 소개</string>
     <string name="text_duplicate_check">중복확인</string>
+    <string name="text_duplicated_group_name">중복된 그룹 이름입니다. 변경해주세요!</string>
+    <string name="text_un_duplicated_group_name">사용 가능한 그룹 이름입니다!</string>
     <string name="text_create_group">그룹 생성하기</string>
     <string name="text_warning_create_group">그룹명과 그룹 소개를 입력해주세요.</string>
     <string name="text_create_group_success">그룹이 생성되었습니다!</string>
@@ -71,10 +75,14 @@
 
     <!-- 운동 기록 아이템 뷰 -->
     <string name="running_history_label_total_running_time">총 운동시간</string>
+    <string name="running_history_value_total_running_time">%d시간 %d분</string>
     <string name="running_history_label_start_running_time">시작시간</string>
     <string name="running_history_label_finish_running_time">종료시간</string>
     <string name="running_history_label_running_distance">이동거리</string>
+    <string name="running_history_value_running_distance_m">%.0fm</string>
+    <string name="running_history_value_running_distance_km">%.2fkm</string>
     <string name="running_history_label_running_pace">페이스</string>
+    <string name="running_history_value_running_pace">%.2fkm/h</string>
 
     <!-- 그룹 상세보기 화면-->
     <string name="text_headcount">%d명</string>
@@ -105,10 +113,6 @@
     <string name="running_channel_name">활동 추적</string>
     <string name="running_channel_description">달리기 활동을 추적하는 알림 채널입니다.</string>
     <string name="running_map_location_button">🎯</string>
-    <string name="text_join_group">그룹 가입하기</string>
-    <string name="text_duplicated_group_name">중복된 그룹 이름입니다. 변경해주세요!</string>
-    <string name="text_un_duplicated_group_name">사용 가능한 그룹 이름입니다!</string>
-    <string name="text_like_count">좋아요 %d개</string>
 
     <!--라닝 종료 화면-->
     <string name="running_finish_tool_bar">러닝 종료</string>


### PR DESCRIPTION
## 😎 작업 내용
- 러닝 히스토리 아이템 UI 개선

## 🧐 변경된 내용
- xml에서 바인딩 어댑터 대신 확장 함수를 이용해봤는데 가독성이 떨어져서 고민입니다.
- 프로그레스바 부분도 마찬가지로 데이터 바인딩에서 최대한 처리를 하려고 했는데... , , ,

## 🥳 동작 화면
- 러닝 히스토리 아이템 레이아웃 적용 화면

| 레이아웃 적용 | 텍스트 포맷 적용 |
| --------------- | ---------------------- |
| <img src="https://user-images.githubusercontent.com/44428543/205454104-da2e17fa-34ad-4610-a82d-e2feaa4049d3.png" height=700 /> | <img src="https://user-images.githubusercontent.com/44428543/205454225-8d32506a-cb4f-4e8e-be96-52fcfd9d9c5d.png" height=700 /> |

- 프로그레스바 적용 화면

https://user-images.githubusercontent.com/44428543/205454383-8144957b-87f6-47d9-af71-c90489db5f07.mp4


## 🤯 이슈 번호
- #71 

## 논의한 내용
- xml의 가독성 떨어지는 로직은 바인딩 어댑터로
- 뷰의 depth 줄이자
- data binding의 import, instanceof 사용법
