### PR TITLE
게시글 탭 Reactive 처리 대신 페이징처리로 변경

### DIFF
--- a/data/build.gradle
+++ b/data/build.gradle
@@ -60,4 +60,7 @@ dependencies {
     implementation "androidx.room:room-runtime:$roomVersion"
     annotationProcessor "androidx.room:room-compiler:$roomVersion"
     kapt "androidx.room:room-compiler:$roomVersion"
+
+    // Paging3
+    implementation "androidx.paging:paging-runtime:$paging3Version"
 }

--- a/data/src/main/java/com/whyranoid/data/post/MyPostPagingDataSource.kt
+++ b/data/src/main/java/com/whyranoid/data/post/MyPostPagingDataSource.kt
@@ -40,7 +40,7 @@ class MyPostPagingDataSource @Inject constructor(
             // 현재 페이지
             val currentPage = params.key ?: db.collection(CollectionId.POST_COLLECTION)
                 .whereEqualTo(AUTHOR_ID, myUid)
-                .limit(10)
+                .limit(DATA_COUNT_PER_PAGE)
                 .get()
                 .await()
 
@@ -121,7 +121,7 @@ class MyPostPagingDataSource @Inject constructor(
             // 마지막 스냅샷 이후 페이지 불러오기
             val nextPage = db.collection(CollectionId.POST_COLLECTION)
                 .whereEqualTo(AUTHOR_ID, myUid)
-                .limit(10)
+                .limit(DATA_COUNT_PER_PAGE)
                 .startAfter(lastDocumentSnapshot)
                 .get()
                 .await()
@@ -138,5 +138,9 @@ class MyPostPagingDataSource @Inject constructor(
 
     fun setMyUid(myUid: String) {
         this.myUid = myUid
+    }
+
+    companion object {
+        private const val DATA_COUNT_PER_PAGE = 10L
     }
 }

--- a/data/src/main/java/com/whyranoid/data/post/MyPostPagingDataSource.kt
+++ b/data/src/main/java/com/whyranoid/data/post/MyPostPagingDataSource.kt
@@ -3,11 +3,10 @@ package com.whyranoid.data.post
 import androidx.paging.PagingSource
 import androidx.paging.PagingState
 import com.google.firebase.firestore.FirebaseFirestore
-import com.google.firebase.firestore.Query
 import com.google.firebase.firestore.QuerySnapshot
 import com.whyranoid.data.constant.CollectionId
 import com.whyranoid.data.constant.FieldId
-import com.whyranoid.data.constant.FieldId.UPDATED_AT
+import com.whyranoid.data.constant.FieldId.AUTHOR_ID
 import com.whyranoid.data.model.GroupInfoResponse
 import com.whyranoid.data.model.RecruitPostResponse
 import com.whyranoid.data.model.RunningPostResponse
@@ -37,9 +36,10 @@ class MyPostPagingDataSource @Inject constructor(
     override suspend fun load(params: LoadParams<QuerySnapshot>): LoadResult<QuerySnapshot, Post> {
         return try {
             val postList = mutableListOf<Post>()
+
             // 현재 페이지
             val currentPage = params.key ?: db.collection(CollectionId.POST_COLLECTION)
-                .orderBy(UPDATED_AT, Query.Direction.DESCENDING)
+                .whereEqualTo(AUTHOR_ID, myUid)
                 .limit(10)
                 .get()
                 .await()
@@ -120,8 +120,9 @@ class MyPostPagingDataSource @Inject constructor(
 
             // 마지막 스냅샷 이후 페이지 불러오기
             val nextPage = db.collection(CollectionId.POST_COLLECTION)
-                .orderBy(UPDATED_AT, Query.Direction.DESCENDING)
-                .limit(10).startAfter(lastDocumentSnapshot)
+                .whereEqualTo(AUTHOR_ID, myUid)
+                .limit(10)
+                .startAfter(lastDocumentSnapshot)
                 .get()
                 .await()
 

--- a/data/src/main/java/com/whyranoid/data/post/MyPostPagingDataSource.kt
+++ b/data/src/main/java/com/whyranoid/data/post/MyPostPagingDataSource.kt
@@ -1,0 +1,141 @@
+package com.whyranoid.data.post
+
+import androidx.paging.PagingSource
+import androidx.paging.PagingState
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.Query
+import com.google.firebase.firestore.QuerySnapshot
+import com.whyranoid.data.constant.CollectionId
+import com.whyranoid.data.constant.FieldId
+import com.whyranoid.data.constant.FieldId.UPDATED_AT
+import com.whyranoid.data.model.GroupInfoResponse
+import com.whyranoid.data.model.RecruitPostResponse
+import com.whyranoid.data.model.RunningPostResponse
+import com.whyranoid.data.model.UserResponse
+import com.whyranoid.data.model.toGroupInfo
+import com.whyranoid.data.model.toUser
+import com.whyranoid.domain.model.Post
+import com.whyranoid.domain.model.RecruitPost
+import com.whyranoid.domain.model.RunningHistory
+import com.whyranoid.domain.model.RunningPost
+import com.whyranoid.domain.model.toRule
+import kotlinx.coroutines.tasks.await
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class MyPostPagingDataSource @Inject constructor(
+    private val db: FirebaseFirestore
+) : PagingSource<QuerySnapshot, Post>() {
+
+    private lateinit var myUid: String
+
+    override fun getRefreshKey(state: PagingState<QuerySnapshot, Post>): QuerySnapshot? {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun load(params: LoadParams<QuerySnapshot>): LoadResult<QuerySnapshot, Post> {
+        return try {
+            val postList = mutableListOf<Post>()
+            // 현재 페이지
+            val currentPage = params.key ?: db.collection(CollectionId.POST_COLLECTION)
+                .orderBy(UPDATED_AT, Query.Direction.DESCENDING)
+                .limit(10)
+                .get()
+                .await()
+
+            // Post 타입 캐스팅
+            // TODO 예외 처리
+            currentPage.forEach { document ->
+
+                if (document[FieldId.RUNNING_HISTORY_ID] != null) {
+                    document.toObject(RunningPostResponse::class.java).let { postResponse ->
+                        val authorResponse = db.collection(CollectionId.USERS_COLLECTION)
+                            .document(postResponse.authorId)
+                            .get()
+                            .await()
+                            .toObject(UserResponse::class.java)
+
+                        authorResponse?.let {
+                            val runningHistory =
+                                db.collection(CollectionId.RUNNING_HISTORY_COLLECTION)
+                                    .document(postResponse.runningHistoryId)
+                                    .get()
+                                    .await()
+                                    .toObject(RunningHistory::class.java)
+
+                            runningHistory?.let {
+                                postList.add(
+                                    RunningPost(
+                                        postId = postResponse.postId,
+                                        author = authorResponse.toUser(),
+                                        updatedAt = postResponse.updatedAt,
+                                        runningHistory = it,
+                                        likeCount = 0,
+                                        content = postResponse.content
+                                    )
+                                )
+                            }
+                        }
+                    }
+                } else {
+                    document.toObject(RecruitPostResponse::class.java).let { postResponse ->
+                        val authorResponse = db.collection(CollectionId.USERS_COLLECTION)
+                            .document(postResponse.authorId)
+                            .get()
+                            .await()
+                            .toObject(UserResponse::class.java)
+
+                        authorResponse?.let {
+                            val groupInfoResponse = db.collection(CollectionId.GROUPS_COLLECTION)
+                                .document(postResponse.groupId)
+                                .get()
+                                .await()
+                                .toObject(GroupInfoResponse::class.java)
+
+                            groupInfoResponse?.let {
+                                val author = authorResponse.toUser()
+                                postList.add(
+                                    RecruitPost(
+                                        postId = postResponse.postId,
+                                        author = author,
+                                        updatedAt = postResponse.updatedAt,
+                                        groupInfo = groupInfoResponse
+                                            .toGroupInfo(
+                                                author,
+                                                rules = groupInfoResponse.rules.map {
+                                                    it.toRule()
+                                                }
+                                            )
+                                    )
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+
+            // 마지막 스냅샷 저장
+            val lastDocumentSnapshot = currentPage.documents[currentPage.size() - 1]
+
+            // 마지막 스냅샷 이후 페이지 불러오기
+            val nextPage = db.collection(CollectionId.POST_COLLECTION)
+                .orderBy(UPDATED_AT, Query.Direction.DESCENDING)
+                .limit(10).startAfter(lastDocumentSnapshot)
+                .get()
+                .await()
+
+            LoadResult.Page(
+                data = postList,
+                prevKey = null,
+                nextKey = nextPage
+            )
+        } catch (e: Exception) {
+            LoadResult.Error(e)
+        }
+    }
+
+    fun setMyUid(myUid: String) {
+        this.myUid = myUid
+    }
+}

--- a/data/src/main/java/com/whyranoid/data/post/PostDataSourceImpl.kt
+++ b/data/src/main/java/com/whyranoid/data/post/PostDataSourceImpl.kt
@@ -253,14 +253,12 @@ class PostDataSourceImpl @Inject constructor(
 
                 val previousRecruitPostId =
                     previousRecruitPost.toObjects(RecruitPostResponse::class.java).first().postId
+
                 db.collection(CollectionId.POST_COLLECTION)
                     .document(previousRecruitPostId)
-                    .set(
-                        RecruitPostResponse(
-                            postId = postId,
-                            authorId = authorUid,
-                            updatedAt = System.currentTimeMillis(),
-                            groupId = groupUid
+                    .update(
+                        mapOf(
+                            UPDATED_AT to System.currentTimeMillis()
                         )
                     ).addOnSuccessListener {
                         cancellableContinuation.resume(true)

--- a/data/src/main/java/com/whyranoid/data/post/PostDataSourceImpl.kt
+++ b/data/src/main/java/com/whyranoid/data/post/PostDataSourceImpl.kt
@@ -31,7 +31,8 @@ class PostDataSourceImpl @Inject constructor(
     private val db: FirebaseFirestore
 ) : PostDataSource {
 
-    //  TODO : 조금 더 간결하게 처리 필요.
+    // TODO : 조금 더 간결하게 처리 필요.
+    // TODO : 페이징 처리가 잘 끝나면 삭제
     override fun getAllPostFlow(): Flow<List<Post>> =
         callbackFlow {
             db.collection(CollectionId.POST_COLLECTION)
@@ -124,6 +125,7 @@ class PostDataSourceImpl @Inject constructor(
             awaitClose()
         }
 
+    // TODO : 페이징 처리가 잘 끝나면 삭제
     override fun getMyPostFlow(uid: String): Flow<List<Post>> =
         callbackFlow {
             db.collection(CollectionId.POST_COLLECTION)
@@ -131,10 +133,10 @@ class PostDataSourceImpl @Inject constructor(
                 .orderBy(UPDATED_AT, Query.Direction.DESCENDING)
                 .addSnapshotListener { snapshot, _ ->
                     val postList = mutableListOf<Post>()
-                    snapshot?.forEach { docuemnt ->
+                    snapshot?.forEach { document ->
 
-                        if (docuemnt[RUNNING_HISTORY_ID] != null) {
-                            docuemnt.toObject(RunningPostResponse::class.java).let { postResponse ->
+                        if (document[RUNNING_HISTORY_ID] != null) {
+                            document.toObject(RunningPostResponse::class.java).let { postResponse ->
                                 db.collection(CollectionId.USERS_COLLECTION)
                                     .document(postResponse.authorId)
                                     .get()
@@ -171,7 +173,7 @@ class PostDataSourceImpl @Inject constructor(
                                     }
                             }
                         } else {
-                            docuemnt.toObject(RecruitPostResponse::class.java).let { postResponse ->
+                            document.toObject(RecruitPostResponse::class.java).let { postResponse ->
 
                                 db.collection(CollectionId.USERS_COLLECTION)
                                     .document(postResponse.authorId)

--- a/data/src/main/java/com/whyranoid/data/post/PostPagingDataSource.kt
+++ b/data/src/main/java/com/whyranoid/data/post/PostPagingDataSource.kt
@@ -39,7 +39,7 @@ class PostPagingDataSource @Inject constructor(
             // 현재 페이지
             val currentPage = params.key ?: db.collection(POST_COLLECTION)
                 .orderBy(UPDATED_AT, Query.Direction.DESCENDING)
-                .limit(10)
+                .limit(DATA_COUNT_PER_PAGE)
                 .get()
                 .await()
 
@@ -120,7 +120,7 @@ class PostPagingDataSource @Inject constructor(
             // 마지막 스냅샷 이후 페이지 불러오기
             val nextPage = db.collection(POST_COLLECTION)
                 .orderBy(UPDATED_AT, Query.Direction.DESCENDING)
-                .limit(10).startAfter(lastDocumentSnapshot)
+                .limit(DATA_COUNT_PER_PAGE).startAfter(lastDocumentSnapshot)
                 .get()
                 .await()
 
@@ -132,5 +132,9 @@ class PostPagingDataSource @Inject constructor(
         } catch (e: Exception) {
             LoadResult.Error(e)
         }
+    }
+
+    companion object {
+        private const val DATA_COUNT_PER_PAGE = 10L
     }
 }

--- a/data/src/main/java/com/whyranoid/data/post/PostPagingDataSource.kt
+++ b/data/src/main/java/com/whyranoid/data/post/PostPagingDataSource.kt
@@ -1,0 +1,136 @@
+package com.whyranoid.data.post
+
+import androidx.paging.PagingSource
+import androidx.paging.PagingState
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.Query
+import com.google.firebase.firestore.QuerySnapshot
+import com.whyranoid.data.constant.CollectionId
+import com.whyranoid.data.constant.CollectionId.POST_COLLECTION
+import com.whyranoid.data.constant.FieldId.RUNNING_HISTORY_ID
+import com.whyranoid.data.constant.FieldId.UPDATED_AT
+import com.whyranoid.data.model.GroupInfoResponse
+import com.whyranoid.data.model.RecruitPostResponse
+import com.whyranoid.data.model.RunningPostResponse
+import com.whyranoid.data.model.UserResponse
+import com.whyranoid.data.model.toGroupInfo
+import com.whyranoid.data.model.toUser
+import com.whyranoid.domain.model.Post
+import com.whyranoid.domain.model.RecruitPost
+import com.whyranoid.domain.model.RunningHistory
+import com.whyranoid.domain.model.RunningPost
+import com.whyranoid.domain.model.toRule
+import kotlinx.coroutines.tasks.await
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class PostPagingDataSource @Inject constructor(
+    private val db: FirebaseFirestore
+) : PagingSource<QuerySnapshot, Post>() {
+
+    override fun getRefreshKey(state: PagingState<QuerySnapshot, Post>): QuerySnapshot? {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun load(params: LoadParams<QuerySnapshot>): LoadResult<QuerySnapshot, Post> {
+        return try {
+            val postList = mutableListOf<Post>()
+            // 현재 페이지
+            val currentPage = params.key ?: db.collection(POST_COLLECTION)
+                .orderBy(UPDATED_AT, Query.Direction.DESCENDING)
+                .limit(10)
+                .get()
+                .await()
+
+            // Post 타입 캐스팅
+            // TODO 예외 처리
+            currentPage.forEach { document ->
+
+                if (document[RUNNING_HISTORY_ID] != null) {
+                    document.toObject(RunningPostResponse::class.java).let { postResponse ->
+                        val authorResponse = db.collection(CollectionId.USERS_COLLECTION)
+                            .document(postResponse.authorId)
+                            .get()
+                            .await()
+                            .toObject(UserResponse::class.java)
+
+                        authorResponse?.let {
+                            val runningHistory =
+                                db.collection(CollectionId.RUNNING_HISTORY_COLLECTION)
+                                    .document(postResponse.runningHistoryId)
+                                    .get()
+                                    .await()
+                                    .toObject(RunningHistory::class.java)
+
+                            runningHistory?.let {
+                                postList.add(
+                                    RunningPost(
+                                        postId = postResponse.postId,
+                                        author = authorResponse.toUser(),
+                                        updatedAt = postResponse.updatedAt,
+                                        runningHistory = it,
+                                        likeCount = 0,
+                                        content = postResponse.content
+                                    )
+                                )
+                            }
+                        }
+                    }
+                } else {
+                    document.toObject(RecruitPostResponse::class.java).let { postResponse ->
+                        val authorResponse = db.collection(CollectionId.USERS_COLLECTION)
+                            .document(postResponse.authorId)
+                            .get()
+                            .await()
+                            .toObject(UserResponse::class.java)
+
+                        authorResponse?.let {
+                            val groupInfoResponse = db.collection(CollectionId.GROUPS_COLLECTION)
+                                .document(postResponse.groupId)
+                                .get()
+                                .await()
+                                .toObject(GroupInfoResponse::class.java)
+
+                            groupInfoResponse?.let {
+                                val author = authorResponse.toUser()
+                                postList.add(
+                                    RecruitPost(
+                                        postId = postResponse.postId,
+                                        author = author,
+                                        updatedAt = postResponse.updatedAt,
+                                        groupInfo = groupInfoResponse
+                                            .toGroupInfo(
+                                                author,
+                                                rules = groupInfoResponse.rules.map {
+                                                    it.toRule()
+                                                }
+                                            )
+                                    )
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+
+            // 마지막 스냅샷 저장
+            val lastDocumentSnapshot = currentPage.documents[currentPage.size() - 1]
+
+            // 마지막 스냅샷 이후 페이지 불러오기
+            val nextPage = db.collection(POST_COLLECTION)
+                .orderBy(UPDATED_AT, Query.Direction.DESCENDING)
+                .limit(10).startAfter(lastDocumentSnapshot)
+                .get()
+                .await()
+
+            LoadResult.Page(
+                data = postList,
+                prevKey = null,
+                nextKey = nextPage
+            )
+        } catch (e: Exception) {
+            LoadResult.Error(e)
+        }
+    }
+}

--- a/data/src/main/java/com/whyranoid/data/post/PostRepositoryImpl.kt
+++ b/data/src/main/java/com/whyranoid/data/post/PostRepositoryImpl.kt
@@ -1,17 +1,35 @@
 package com.whyranoid.data.post
 
+import androidx.paging.Pager
+import androidx.paging.PagingConfig
+import androidx.paging.PagingData
 import com.whyranoid.domain.model.Post
 import com.whyranoid.domain.repository.PostRepository
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
 class PostRepositoryImpl @Inject constructor(
-    private val postDataSource: PostDataSource
+    private val postDataSource: PostDataSource,
+    private val postPagingDataSource: PostPagingDataSource,
+    private val myPostPagingDataSource: MyPostPagingDataSource
 ) : PostRepository {
 
-    // TODO : 페이징처리하기
-    override fun getPagingPosts(): Flow<List<Post>> {
-        TODO("Not yet implemented")
+    // TODO : 캐싱하기
+    override fun getPagingPosts(): Flow<PagingData<Post>> {
+        return Pager(
+            PagingConfig(pageSize = 5)
+        ) {
+            postPagingDataSource
+        }.flow
+    }
+
+    override fun getMyPagingPosts(uid: String): Flow<PagingData<Post>> {
+        myPostPagingDataSource.setMyUid(uid)
+        return Pager(
+            PagingConfig(pageSize = 5)
+        ) {
+            myPostPagingDataSource
+        }.flow
     }
 
     override fun getAllPostFlow(): Flow<List<Post>> {

--- a/domain/src/main/java/com/whyranoid/domain/repository/PostRepository.kt
+++ b/domain/src/main/java/com/whyranoid/domain/repository/PostRepository.kt
@@ -1,5 +1,6 @@
 package com.whyranoid.domain.repository
 
+import androidx.paging.PagingData
 import com.whyranoid.domain.model.Post
 import kotlinx.coroutines.flow.Flow
 
@@ -7,7 +8,9 @@ interface PostRepository {
 
     // TODO : 페이징 처리
     // 글(홍보 / 인증) 페이징으로 가져오기 - 리모트
-    fun getPagingPosts(): Flow<List<Post>>
+    fun getPagingPosts(): Flow<PagingData<Post>>
+
+    fun getMyPagingPosts(uid: String): Flow<PagingData<Post>>
 
     fun getAllPostFlow(): Flow<List<Post>>
 

--- a/domain/src/main/java/com/whyranoid/domain/usecase/GetMyPagingPostsUseCase.kt
+++ b/domain/src/main/java/com/whyranoid/domain/usecase/GetMyPagingPostsUseCase.kt
@@ -1,17 +1,18 @@
 package com.whyranoid.domain.usecase
 
+import androidx.paging.PagingData
 import com.whyranoid.domain.model.Post
 import com.whyranoid.domain.repository.AccountRepository
 import com.whyranoid.domain.repository.PostRepository
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
-// TODO : 페이징 처리가 잘 끝나면 삭제
-class GetMyPostUseCase @Inject constructor(
+class GetMyPagingPostsUseCase @Inject constructor(
     private val accountRepository: AccountRepository,
     private val postRepository: PostRepository
 ) {
-    suspend operator fun invoke(): Flow<List<Post>> {
-        return postRepository.getMyPostFlow(accountRepository.getUid())
+
+    suspend operator fun invoke(): Flow<PagingData<Post>> {
+        return postRepository.getMyPagingPosts(accountRepository.getUid())
     }
 }

--- a/domain/src/main/java/com/whyranoid/domain/usecase/GetPagingPostsUseCase.kt
+++ b/domain/src/main/java/com/whyranoid/domain/usecase/GetPagingPostsUseCase.kt
@@ -1,12 +1,13 @@
 package com.whyranoid.domain.usecase
 
+import androidx.paging.PagingData
 import com.whyranoid.domain.model.Post
 import com.whyranoid.domain.repository.PostRepository
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
 class GetPagingPostsUseCase @Inject constructor(private val postRepository: PostRepository) {
-    operator fun invoke(): Flow<List<Post>> {
+    operator fun invoke(): Flow<PagingData<Post>> {
         return postRepository.getPagingPosts()
     }
 }

--- a/domain/src/main/java/com/whyranoid/domain/usecase/GetPostsUseCase.kt
+++ b/domain/src/main/java/com/whyranoid/domain/usecase/GetPostsUseCase.kt
@@ -5,6 +5,7 @@ import com.whyranoid.domain.repository.PostRepository
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
+// TODO : 페이징 처리가 잘 끝나면 삭제
 class GetPostsUseCase @Inject constructor(
     private val postRepository: PostRepository
 ) {

--- a/presentation/build.gradle
+++ b/presentation/build.gradle
@@ -56,6 +56,7 @@ dependencies {
     implementation "androidx.appcompat:appcompat:$appcompatVersion"
     implementation "com.google.android.material:material:$materialVersion"
     implementation "androidx.constraintlayout:constraintlayout:$constraintlayoutVersion"
+    implementation "androidx.paging:paging-runtime-ktx:$paging3Version"
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$junitUiVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$espressoCoreVersion"

--- a/presentation/src/main/java/com/whyranoid/presentation/community/CommunityItemFragment.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/community/CommunityItemFragment.kt
@@ -13,6 +13,7 @@ import com.whyranoid.presentation.databinding.FragmentCommunityItemBinding
 import com.whyranoid.presentation.util.getSerializableData
 import com.whyranoid.presentation.util.repeatWhenUiStarted
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
@@ -117,9 +118,9 @@ internal class CommunityItemFragment :
             }
 
             viewLifecycleOwner.repeatWhenUiStarted {
-                viewModel.postList.collect { postList ->
+                viewModel.pagingPost.collectLatest { postList ->
                     removeShimmer()
-                    postAdapter.submitList(postList)
+                    postAdapter.submitData(postList)
                 }
             }
         }
@@ -162,9 +163,9 @@ internal class CommunityItemFragment :
             }
 
             viewLifecycleOwner.repeatWhenUiStarted {
-                viewModel.myPostList.collect { myPostList ->
+                viewModel.getMyPagingPostsUseCase().collectLatest { myPostList ->
                     removeShimmer()
-                    postAdapter.submitList(myPostList)
+                    postAdapter.submitData(myPostList)
                 }
             }
         }

--- a/presentation/src/main/java/com/whyranoid/presentation/community/CommunityViewModel.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/community/CommunityViewModel.kt
@@ -2,11 +2,10 @@ package com.whyranoid.presentation.community
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.whyranoid.domain.model.Post
 import com.whyranoid.domain.usecase.DeletePostUseCase
 import com.whyranoid.domain.usecase.GetMyGroupListUseCase
-import com.whyranoid.domain.usecase.GetMyPostUseCase
-import com.whyranoid.domain.usecase.GetPostsUseCase
+import com.whyranoid.domain.usecase.GetMyPagingPostsUseCase
+import com.whyranoid.domain.usecase.GetPagingPostsUseCase
 import com.whyranoid.domain.usecase.JoinGroupUseCase
 import com.whyranoid.presentation.model.GroupInfoUiModel
 import com.whyranoid.presentation.model.toGroupInfoUiModel
@@ -25,27 +24,21 @@ import javax.inject.Inject
 @HiltViewModel
 class CommunityViewModel @Inject constructor(
     getMyGroupListUseCase: GetMyGroupListUseCase,
-    getPostsUseCase: GetPostsUseCase,
     private val joinGroupUseCase: JoinGroupUseCase,
-    private val getMyPostUseCase: GetMyPostUseCase,
-    private val deletePostUseCase: DeletePostUseCase
+    private val deletePostUseCase: DeletePostUseCase,
+    getPagingPostsUseCase: GetPagingPostsUseCase,
+    val getMyPagingPostsUseCase: GetMyPagingPostsUseCase
 ) : ViewModel() {
-
-    private val _postList = MutableStateFlow<List<Post>>(emptyList())
-    val postList: StateFlow<List<Post>>
-        get() = _postList.asStateFlow()
 
     private val _myGroupList = MutableStateFlow<List<GroupInfoUiModel>>(emptyList())
     val myGroupList: StateFlow<List<GroupInfoUiModel>>
         get() = _myGroupList.asStateFlow()
 
-    private val _myPostList = MutableStateFlow<List<Post>>(emptyList())
-    val myPostList: StateFlow<List<Post>>
-        get() = _myPostList.asStateFlow()
-
     private val _eventFlow = MutableSharedFlow<Event>()
     val eventFlow: SharedFlow<Event>
         get() = _eventFlow.asSharedFlow()
+
+    val pagingPost = getPagingPostsUseCase()
 
     fun onGroupItemClicked(groupInfo: GroupInfoUiModel) {
         emitEvent(Event.GroupItemClick(groupInfo))
@@ -93,18 +86,6 @@ class CommunityViewModel @Inject constructor(
                 _myGroupList.value = groupInfoList.map { groupInfo ->
                     groupInfo.toGroupInfoUiModel()
                 }
-            }.launchIn(this)
-        }
-
-        getPostsUseCase().onEach { postList ->
-            _postList.value = postList.sortedByDescending { post ->
-                post.updatedAt
-            }
-        }.launchIn(viewModelScope)
-
-        viewModelScope.launch {
-            getMyPostUseCase().onEach { myPostList ->
-                _myPostList.value = myPostList
             }.launchIn(this)
         }
     }

--- a/presentation/src/main/java/com/whyranoid/presentation/community/PostAdapter.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/community/PostAdapter.kt
@@ -4,8 +4,8 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.databinding.ViewDataBinding
+import androidx.paging.PagingDataAdapter
 import androidx.recyclerview.widget.DiffUtil
-import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.whyranoid.domain.model.Post
 import com.whyranoid.domain.model.RecruitPost
@@ -18,7 +18,7 @@ class PostAdapter(
     private val isMyPost: Boolean = false,
     private val itemLongClickListener: (String) -> Unit = {},
     private val buttonClickListener: (String) -> Unit = {}
-) : ListAdapter<Post, PostAdapter.PostViewHolder>(diffUtil) {
+) : PagingDataAdapter<Post, PostAdapter.PostViewHolder>(diffUtil) {
 
     private lateinit var myGroupList: List<GroupInfoUiModel>
 
@@ -84,12 +84,13 @@ class PostAdapter(
     }
 
     override fun onBindViewHolder(holder: PostViewHolder, position: Int) {
-        val curPost = getItem(position)
-        holder.apply {
-            bind(curPost)
-            if (isMyPost) this.itemView.setOnLongClickListener {
-                itemLongClickListener(curPost.postId)
-                true
+        getItem(position)?.let { curPost ->
+            holder.apply {
+                bind(curPost)
+                if (isMyPost) this.itemView.setOnLongClickListener {
+                    itemLongClickListener(curPost.postId)
+                    true
+                }
             }
         }
     }


### PR DESCRIPTION
## 😎 작업 내용
- 기존에 snapshotListener로 구현되어있던 게시글 탭을 Paging3 라이브러리를 활용, 반응형 대신 페이징처리하도록 변경

## 🧐 변경된 내용
- 기존에 snapshotListener로 구현되어있던 게시글 탭을 Paging3 라이브러리를 활용, 반응형 대신 페이징처리하도록 변경

## 🥳 동작 화면
- 페이징~
![paging](https://user-images.githubusercontent.com/90144041/205502295-023484af-8170-44b7-889e-b068b333d020.gif)

## 🤯 이슈 번호
- 이슈 없음

## 🥲 비고
- ~uid를 기반으로 특정한 게시글만 정렬된채로 불러오는 부분이 잘 진행이 되지않고 있습니다.
 그래서 현재 내가 쓴 글은 그냥 모든 게시글이 나오는 중입니다.~
- 내가쓴 글 페이징처리해서 추가적인 commit을 올렸습니다! 
whereEqualTo와 orderBy가 동시에 잘 써지지 않아서 우선 내가 쓴 글은 updatedAt으로 순서가 보장되지않습니다..!!ㅜㅜ
