### PR TITLE
커뮤니티 탭 UI 일부 수정

### DIFF
--- a/presentation/src/main/res/layout/fragment_community.xml
+++ b/presentation/src/main/res/layout/fragment_community.xml
@@ -34,6 +34,8 @@
             android:id="@+id/tab_layout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:background="@color/mogakrun_background"
+            app:tabIndicatorColor="@color/mogakrun_on_primary"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/app_bar">

--- a/presentation/src/main/res/layout/fragment_community.xml
+++ b/presentation/src/main/res/layout/fragment_community.xml
@@ -16,6 +16,7 @@
             android:id="@+id/app_bar"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            app:elevation="0dp"
             app:layout_constraintTop_toTopOf="parent">
 
             <com.google.android.material.appbar.MaterialToolbar
@@ -23,6 +24,8 @@
                 style="@style/Widget.MaterialComponents.Toolbar.Primary"
                 android:layout_width="match_parent"
                 android:layout_height="?attr/actionBarSize"
+                android:background="@color/mogakrun_background"
+                app:titleTextAppearance="@style/MoGakRunText.Bold.Medium"
                 app:title="@string/text_community" />
 
         </com.google.android.material.appbar.AppBarLayout>

--- a/presentation/src/main/res/layout/fragment_create_group.xml
+++ b/presentation/src/main/res/layout/fragment_create_group.xml
@@ -19,6 +19,7 @@
             android:id="@+id/app_bar"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            app:elevation="0dp"
             app:layout_constraintTop_toTopOf="parent">
 
             <com.google.android.material.appbar.MaterialToolbar
@@ -26,7 +27,9 @@
                 style="@style/Widget.MaterialComponents.Toolbar.Primary"
                 android:layout_width="match_parent"
                 android:layout_height="?attr/actionBarSize"
-                app:title="@string/text_create_group" />
+                android:background="@color/mogakrun_background"
+                app:title="@string/text_create_group"
+                app:titleTextAppearance="@style/MoGakRunText.Bold.Medium" />
 
         </com.google.android.material.appbar.AppBarLayout>
 

--- a/presentation/src/main/res/layout/fragment_edit_group.xml
+++ b/presentation/src/main/res/layout/fragment_edit_group.xml
@@ -19,6 +19,7 @@
             android:id="@+id/app_bar"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            app:elevation="0dp"
             app:layout_constraintTop_toTopOf="parent">
 
             <com.google.android.material.appbar.MaterialToolbar
@@ -26,6 +27,8 @@
                 style="@style/Widget.MaterialComponents.Toolbar.Primary"
                 android:layout_width="match_parent"
                 android:layout_height="?attr/actionBarSize"
+                android:background="@color/mogakrun_background"
+                app:titleTextAppearance="@style/MoGakRunText.Bold.Medium"
                 app:title="@string/text_edit_group" />
 
         </com.google.android.material.appbar.AppBarLayout>

--- a/presentation/src/main/res/layout/fragment_group_detail.xml
+++ b/presentation/src/main/res/layout/fragment_group_detail.xml
@@ -20,6 +20,7 @@
             android:id="@+id/app_bar"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            app:elevation="0dp"
             app:layout_constraintTop_toTopOf="parent">
 
             <com.google.android.material.appbar.MaterialToolbar
@@ -27,7 +28,9 @@
                 style="@style/Widget.MaterialComponents.Toolbar.Primary"
                 android:layout_width="match_parent"
                 android:layout_height="?attr/actionBarSize"
+                android:background="@color/mogakrun_background"
                 app:title="@{viewModel.groupInfo.name}"
+                app:titleTextAppearance="@style/MoGakRunText.Bold.Medium"
                 tools:title ="수피치 그룹"/>
 
         </com.google.android.material.appbar.AppBarLayout>

--- a/presentation/src/main/res/layout/item_running_post.xml
+++ b/presentation/src/main/res/layout/item_running_post.xml
@@ -5,6 +5,8 @@
 
     <data>
 
+        <import type="com.whyranoid.presentation.util.ExtensionsKt" />
+
         <variable
             name="runningPost"
             type="com.whyranoid.domain.model.RunningPost" />
@@ -21,7 +23,8 @@
             android:layout_height="50dp"
             android:layout_margin="16dp"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+            app:layout_constraintTop_toTopOf="parent"
+            android:contentDescription="@string/my_run_profile_image_description"/>
 
         <TextView
             android:id="@+id/tv_leader_name"
@@ -31,18 +34,44 @@
             android:text="@{runningPost.author.name}"
             app:layout_constraintBottom_toBottomOf="@id/iv_leader_profile"
             app:layout_constraintStart_toEndOf="@id/iv_leader_profile"
-            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintTop_toTopOf="@id/iv_leader_profile"
             tools:text="수피치" />
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/item_view_running_history"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="16dp"
+        android:background="@drawable/background_rounded"
+        android:backgroundTint="@color/mogakrun_secondary"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/iv_leader_profile"
+        android:elevation="@dimen/cardview_default_elevation">
+
+        <View
+            android:id="@+id/view_running_history_body"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:background="@drawable/background_rounded"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_running_history_date" />
 
         <TextView
             android:id="@+id/tv_running_history_date"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
-            android:layout_marginTop="16dp"
-            android:text="@{runningPost.runningHistory.historyId}"
+            android:layout_marginTop="4dp"
+            android:maxLines="1"
+            android:text="@{ExtensionsKt.toRunningDateString(runningPost.runningHistory.startedAt)}"
+            android:textAppearance="@style/MoGakRunText.Regular.Small"
+            android:textColor="?attr/colorOnSecondary"
+            app:layout_constraintEnd_toEndOf="@id/view_vertical_partition_line"
+            app:layout_constraintHorizontal_bias="0.1"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/iv_leader_profile"
+            app:layout_constraintTop_toTopOf="parent"
             tools:text="2022/09/11" />
 
         <TextView
@@ -51,87 +80,104 @@
             android:layout_height="wrap_content"
             android:layout_marginEnd="20dp"
             android:text="@string/running_history_label_total_running_time"
+            android:textAppearance="@style/MoGakRunText.Light.Small"
             app:layout_constraintBottom_toBottomOf="@id/tv_running_history_date"
             app:layout_constraintEnd_toStartOf="@id/tv_total_running_time"
+            app:layout_constraintStart_toStartOf="@id/view_vertical_partition_line"
             app:layout_constraintTop_toTopOf="@id/tv_running_history_date" />
 
         <TextView
             android:id="@+id/tv_total_running_time"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@{Integer.toString(runningPost.runningHistory.totalRunningTime)}"
+            android:text="@{String.format(@string/running_history_value_total_running_time, runningPost.runningHistory.totalRunningTime / 3600, runningPost.runningHistory.totalRunningTime / 60)}"
+            android:textAppearance="@style/MoGakRunText.Regular.Small"
             app:layout_constraintBottom_toBottomOf="@id/tv_label_total_running_time"
             app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/tv_label_total_running_time"
             app:layout_constraintTop_toTopOf="@id/tv_label_total_running_time"
             tools:text="2시간 22분" />
 
         <View
             android:id="@+id/view_vertical_partition_line"
             android:layout_width="1dp"
-            android:layout_height="100dp"
-            android:layout_marginTop="20dp"
-            android:layout_marginBottom="20dp"
-            android:background="@color/black"
+            android:layout_height="0dp"
+            android:alpha="0.2"
+            android:background="?attr/colorOnSecondary"
+            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/tv_label_total_running_time" />
+            app:layout_constraintTop_toTopOf="@id/view_running_history_body" />
 
         <View
             android:id="@+id/view_horizontal_partition_line"
             android:layout_width="0dp"
             android:layout_height="1dp"
-            android:layout_marginTop="20dp"
-            android:layout_marginBottom="20dp"
-            android:background="@color/black"
-            app:layout_constraintBottom_toBottomOf="@id/view_vertical_partition_line"
+            android:alpha="0.2"
+            android:background="?attr/colorOnSecondary"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="@id/view_vertical_partition_line" />
+            app:layout_constraintTop_toBottomOf="@id/tv_start_time_value" />
 
         <TextView
+            android:id="@+id/tv_start_time_label"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
-            android:layout_marginTop="16dp"
+            android:layout_marginHorizontal="6dp"
+            android:layout_marginTop="12dp"
             android:text="@string/running_history_label_start_running_time"
+            android:textAppearance="@style/MoGakRunText.Light.Small"
+            app:layout_constraintEnd_toStartOf="@id/view_vertical_partition_line"
+            app:layout_constraintHorizontal_bias="0.0"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/tv_running_history_date" />
 
         <TextView
+            android:id="@+id/tv_start_time_value"
+            longToTime="@{runningPost.runningHistory.startedAt}"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginEnd="50dp"
-            android:layout_marginBottom="20dp"
-            app:longToTime="@{runningPost.runningHistory.startedAt}"
-            app:layout_constraintBottom_toBottomOf="@id/view_horizontal_partition_line"
+            android:paddingTop="10dp"
+            android:paddingBottom="20dp"
+            android:textAppearance="@style/MoGakRunText.Regular.Medium"
             app:layout_constraintEnd_toStartOf="@id/view_vertical_partition_line"
+            app:layout_constraintHorizontal_bias="0.6"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_start_time_label"
             tools:text="17:00" />
 
         <TextView
+            android:id="@+id/tv_end_time_label"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="12dp"
-            android:layout_marginTop="16dp"
             android:text="@string/running_history_label_finish_running_time"
+            android:textAppearance="@style/MoGakRunText.Light.Small"
             app:layout_constraintStart_toStartOf="@id/view_vertical_partition_line"
-            app:layout_constraintTop_toBottomOf="@id/tv_running_history_date" />
+            app:layout_constraintTop_toTopOf="@id/tv_start_time_label" />
 
         <TextView
+            longToTime="@{runningPost.runningHistory.finishedAt}"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginEnd="50dp"
             android:layout_marginBottom="20dp"
-            app:longToTime="@{runningPost.runningHistory.finishedAt}"
-            app:layout_constraintBottom_toBottomOf="@id/view_horizontal_partition_line"
-            app:layout_constraintEnd_toEndOf="parent"
+            android:paddingTop="10dp"
+            android:paddingBottom="20dp"
+            android:textAppearance="@style/MoGakRunText.Regular.Medium"
+            app:layout_constraintEnd_toEndOf="@id/view_horizontal_partition_line"
+            app:layout_constraintHorizontal_bias="0.6"
+            app:layout_constraintStart_toEndOf="@id/view_vertical_partition_line"
+            app:layout_constraintTop_toBottomOf="@id/tv_end_time_label"
             tools:text="19:22" />
 
         <TextView
+            android:id="@+id/tv_total_distance_label"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
+            android:layout_marginHorizontal="6dp"
             android:layout_marginTop="12dp"
             android:text="@string/running_history_label_running_distance"
+            android:textAppearance="@style/MoGakRunText.Light.Small"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/view_horizontal_partition_line" />
 
@@ -139,18 +185,24 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="24dp"
-            android:layout_marginEnd="50dp"
-            android:text="@{Double.toString(runningPost.runningHistory.totalDistance)}"
+            android:paddingTop="10dp"
+            android:paddingBottom="20dp"
+            android:text="@{runningPost.runningHistory.totalDistance >= 1000 ? String.format(@string/running_history_value_running_distance_km, runningPost.runningHistory.totalDistance / 1000) : String.format(@string/running_history_value_running_distance_m, runningPost.runningHistory.totalDistance)}"
+            android:textAppearance="@style/MoGakRunText.Regular.Medium"
             app:layout_constraintEnd_toStartOf="@id/view_vertical_partition_line"
+            app:layout_constraintHorizontal_bias="0.6"
+            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/view_horizontal_partition_line"
             tools:text="11.7km" />
 
         <TextView
+            android:id="@+id/tv_total_pace_label"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="12dp"
             android:layout_marginTop="12dp"
             android:text="@string/running_history_label_running_pace"
+            android:textAppearance="@style/MoGakRunText.Light.Small"
             app:layout_constraintStart_toStartOf="@id/view_vertical_partition_line"
             app:layout_constraintTop_toBottomOf="@id/view_horizontal_partition_line" />
 
@@ -158,11 +210,17 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="24dp"
-            android:layout_marginEnd="50dp"
-            android:text="@{Double.toString(runningPost.runningHistory.pace)}"
-            app:layout_constraintEnd_toEndOf="parent"
+            android:paddingTop="10dp"
+            android:paddingBottom="20dp"
+            android:text="@{String.format(@string/running_history_value_running_pace, runningPost.runningHistory.pace)}"
+            android:textAppearance="@style/MoGakRunText.Regular.Medium"
+            app:layout_constraintEnd_toEndOf="@id/view_horizontal_partition_line"
+            app:layout_constraintHorizontal_bias="0.6"
+            app:layout_constraintStart_toEndOf="@id/view_vertical_partition_line"
             app:layout_constraintTop_toBottomOf="@id/view_horizontal_partition_line"
             tools:text="6.3km/h" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
         <TextView
             android:id="@+id/tv_like_cnt"
@@ -173,7 +231,7 @@
             android:text="@{@string/text_like_count(runningPost.likeCount)}"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/view_vertical_partition_line"
+            app:layout_constraintTop_toBottomOf="@id/item_view_running_history"
             tools:text="좋아요 0개" />
 
         <TextView


### PR DESCRIPTION
## 😎 작업 내용
- 여러분들이 만들어놓으신 이쁜 레이아웃들에 맞춰 커뮤니티 탭의 UI도 수정을 하였습니다.

## 🧐 변경된 내용
- 커뮤니티 탭의 전체적인 툴바 레이아웃 수정
  - 커뮤니티 탭
  - 그룹 디테일 페이지
  - 그룹 수정 페이지
  - 그룹 생성 페이지
- 커뮤니티 탭의 탭 레이아웃 수정
- 인증 글 레이아웃 수정  

## 🥳 동작 화면
- 커뮤니티 탭의 툴바들
![toolbar](https://user-images.githubusercontent.com/90144041/205683459-3daf4865-4f43-4183-aef9-bcaa3f3dd7da.gif)

- 인증 글
![Screenshot 2022-12-06 at 1 01 26 AM](https://user-images.githubusercontent.com/90144041/205683636-a17b9098-a370-4cf7-b0fa-1c5ed07845bd.png)

## 🤯 이슈 번호
- 이슈 없음

## 🥲 비고
- 게시글들의 전체적인 레이아웃은 나중에 논의하고 다시 정해지면 아예 새로 짤 예정입니다.
- 인증 글 xml을 보면 현재 constraint layout이 중첩인 구조로 되어있는데 병희님이 만드신 레이아웃 자체를 가져와서 그렇습니다.
추후에 재활용 가능한 파일로 분리할 수 있을 것 같아서 그렇게 수정하면 좋을 것 같습니다!