### PR TITLE
러닝탭 관련 버그 수정

### DIFF
--- a/presentation/src/main/java/com/whyranoid/presentation/running/RunningDataManager.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/running/RunningDataManager.kt
@@ -84,7 +84,7 @@ class RunningDataManager @Inject constructor() {
                 distance
             )
             val newTotalDistance = prevRunningData.totalDistance + distance.first()
-            val newPace = newTotalDistance / newRunningTime
+            val newPace = if (newRunningTime == 0) 0.0 else newTotalDistance / newRunningTime
             val newRunningPositionList =
                 prevRunningData.runningPositionList.toList().map { it.toMutableList() }
                     .also { it[it.lastIndex].add(runningPosition) }

--- a/presentation/src/main/java/com/whyranoid/presentation/runningfinish/RunningFinishFragment.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/runningfinish/RunningFinishFragment.kt
@@ -84,9 +84,14 @@ internal class RunningFinishFragment :
 
     private fun handleEvent(event: Event) {
         when (event) {
-            is Event.NegativeButtonButtonClick -> findNavController().popBackStack()
+            is Event.NegativeButtonButtonClick -> handleNegativeButtonClicked()
             is Event.PositiveButtonClick -> handlePositiveButtonClicked(event.runningHistory)
         }
+    }
+
+    private fun handleNegativeButtonClicked() {
+        binding.mapFragmentLayout.visibility = View.INVISIBLE
+        findNavController().popBackStack()
     }
 
     private fun handlePositiveButtonClicked(runningHistory: RunningHistoryUiModel) {

--- a/presentation/src/main/java/com/whyranoid/presentation/runningstart/RunningStartFragment.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/runningstart/RunningStartFragment.kt
@@ -52,17 +52,7 @@ internal class RunningStartFragment :
                     RUNNING_FINISH_DATA_KEY
                 )
 
-            // 결과 넘겨주기
-            if (runningFinishData?.runningPositionList.isNullOrEmpty().not()) {
-                runningFinishData?.let {
-                    val direction =
-                        RunningStartFragmentDirections.actionRunningStartFragmentToRunningFinish(
-                            runningFinishData
-                        )
-                    findNavController().navigate(direction)
-                } ?: Snackbar.make(binding.root, getString(R.string.running_start_error_message), Snackbar.LENGTH_SHORT)
-                    .show()
-            }
+            navigateToRunningFinish(runningFinishData)
         }
     }
 
@@ -153,6 +143,23 @@ internal class RunningStartFragment :
             }
             .setNegativeButton("그건 싫어요") { _, _ ->
             }
+            .show()
+    }
+
+    private fun navigateToRunningFinish(runningFinishData: RunningFinishData?) {
+        runningFinishData?.let { it ->
+            if (it.runningPositionList.flatten().isNotEmpty()) {
+                val direction =
+                    RunningStartFragmentDirections.actionRunningStartFragmentToRunningFinish(
+                        it
+                    )
+                findNavController().navigate(direction)
+            }
+        } ?: Snackbar.make(
+            binding.root,
+            getString(R.string.running_start_error_message),
+            Snackbar.LENGTH_SHORT
+        )
             .show()
     }
 }

--- a/presentation/src/main/res/layout/fragment_running_finish.xml
+++ b/presentation/src/main/res/layout/fragment_running_finish.xml
@@ -3,8 +3,10 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <data>
-        <import type="com.whyranoid.presentation.model.UiState"/>
-        <import type="android.view.View"/>
+
+        <import type="com.whyranoid.presentation.model.UiState" />
+
+        <import type="android.view.View" />
 
         <variable
             name="vm"
@@ -32,12 +34,13 @@
         </com.google.android.material.appbar.AppBarLayout>
 
         <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/map_fragment_layout"
             android:layout_width="match_parent"
             android:layout_height="0dp"
             app:layout_constraintBottom_toTopOf="@id/running_history_item"
             app:layout_constraintTop_toBottomOf="@id/tool_bar">
 
-            <fragment xmlns:app="http://schemas.android.com/apk/res-auto"
+            <fragment
                 android:id="@+id/map_fragment"
                 android:name="com.naver.maps.map.MapFragment"
                 android:layout_width="match_parent"
@@ -81,27 +84,6 @@
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toEndOf="@id/btn_positive" />
-
-        <FrameLayout
-            android:id="@+id/frame_progress_running"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:background="@color/black"
-            android:alpha="0.8"
-            android:translationZ="@{vm.runningFinishDataState instanceof UiState.Success ? 0f : 10f }"
-            android:visibility="@{vm.runningFinishDataState instanceof UiState.Success ? View.GONE : View.VISIBLE }">
-
-            <com.google.android.material.progressindicator.CircularProgressIndicator
-                android:id="@+id/progressindicator_running"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                android:contentDescription="@string/running_finish_progress_description"
-                android:indeterminate="true"
-                android:visibility="@{vm.runningFinishDataState instanceof UiState.Success ? View.GONE : View.VISIBLE }"
-                app:indicatorColor="?attr/colorOnPrimary" />
-
-        </FrameLayout>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/presentation/src/main/res/navigation/navigation_graph.xml
+++ b/presentation/src/main/res/navigation/navigation_graph.xml
@@ -88,7 +88,9 @@
             app:argType="com.whyranoid.presentation.model.RunningHistoryUiModel" />
         <action
             android:id="@+id/action_createRunningPostFragment_to_communityFragment"
-            app:destination="@id/communityFragment" />
+            app:destination="@id/communityFragment"
+            app:popUpTo="@id/runningStartFragment"
+            app:popUpToInclusive="true" />
     </fragment>
     <fragment
         android:id="@+id/runningFinishFragment"


### PR DESCRIPTION
## 😎 작업 내용
- 러닝탭 관련 버그, 이슈들 해결

## 🧐 변경된 내용
-  러닝 종료화면에서 인증글 작성 시 백스택 버그 수정 (nav_graph 수정)
- 위치 정보 없을 때 러닝 종료화면에서 앱이 터지는 버그 수정 (RunningStartFragment 수정)
- 러닝종료 화면 종료시 지도 깜빡임 현상 수정 (RunningFinishFragment 수정)
- 달린 시간 0초일 때 NaN 예외 처리 (RunningDataManager 수정)

## 🥳 동작 화면
- 동작 화면 없음

## 🤯 이슈 번호
- #75 
