### PR TITLE
shimmer 설정 변경, 메서드 컨벤션 맞추기, 운동 종료 알림 정렬 로직 변경

### DIFF
--- a/presentation/src/main/java/com/whyranoid/presentation/community/CommunityFragment.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/community/CommunityFragment.kt
@@ -16,7 +16,10 @@ internal class CommunityFragment :
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        initViews()
+    }
 
+    private fun initViews() {
         val adapter = CommunityCategoryAdapter(this)
         setTabLayout(adapter)
     }

--- a/presentation/src/main/java/com/whyranoid/presentation/community/CommunityItemFragment.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/community/CommunityItemFragment.kt
@@ -6,6 +6,7 @@ import androidx.core.view.isVisible
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
+import androidx.paging.LoadState
 import com.google.android.material.snackbar.Snackbar
 import com.whyranoid.presentation.R
 import com.whyranoid.presentation.base.BaseFragment
@@ -109,6 +110,13 @@ internal class CommunityItemFragment :
                     viewModel.onGroupJoinButtonClicked(it)
                 }
             )
+
+            viewLifecycleOwner.repeatWhenUiStarted {
+                postAdapter.loadStateFlow.collectLatest { loadStates ->
+                    binding.shimmerCommunity.isVisible = loadStates.refresh is LoadState.Loading
+                }
+            }
+
             binding.rvCommunity.adapter = postAdapter
 
             viewLifecycleOwner.repeatWhenUiStarted {
@@ -119,7 +127,6 @@ internal class CommunityItemFragment :
 
             viewLifecycleOwner.repeatWhenUiStarted {
                 viewModel.pagingPost.collectLatest { postList ->
-                    removeShimmer()
                     postAdapter.submitData(postList)
                 }
             }
@@ -133,9 +140,9 @@ internal class CommunityItemFragment :
         binding.rvCommunity.adapter = myGroupAdapter
 
         viewLifecycleOwner.repeatWhenUiStarted {
-            viewModel.myGroupList.collect { groupList ->
-                removeShimmer()
+            viewModel.myGroupList.collectLatest { groupList ->
                 myGroupAdapter.submitList(groupList.sortedBy { it.name })
+                removeShimmer()
             }
         }
     }
@@ -154,6 +161,13 @@ internal class CommunityItemFragment :
                     }.show()
                 }
             )
+
+            viewLifecycleOwner.repeatWhenUiStarted {
+                postAdapter.loadStateFlow.collectLatest { loadStates ->
+                    binding.shimmerCommunity.isVisible = loadStates.refresh is LoadState.Loading
+                }
+            }
+
             binding.rvCommunity.adapter = postAdapter
 
             viewLifecycleOwner.repeatWhenUiStarted {
@@ -164,7 +178,6 @@ internal class CommunityItemFragment :
 
             viewLifecycleOwner.repeatWhenUiStarted {
                 viewModel.getMyPagingPostsUseCase().collectLatest { myPostList ->
-                    removeShimmer()
                     postAdapter.submitData(myPostList)
                 }
             }

--- a/presentation/src/main/java/com/whyranoid/presentation/community/group/detail/GroupDetailFragment.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/community/group/detail/GroupDetailFragment.kt
@@ -13,6 +13,7 @@ import com.whyranoid.presentation.base.BaseFragment
 import com.whyranoid.presentation.databinding.FragmentGroupDetailBinding
 import com.whyranoid.presentation.util.repeatWhenUiStarted
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
@@ -150,7 +151,7 @@ internal class GroupDetailFragment :
 
             binding.notificationRecyclerView.adapter = notificationAdapter
             viewLifecycleOwner.repeatWhenUiStarted {
-                viewModel.mergedNotifications.collect { notifications ->
+                viewModel.mergedNotifications.collectLatest { notifications ->
                     notificationAdapter.submitList(notifications)
                 }
             }

--- a/presentation/src/main/java/com/whyranoid/presentation/community/group/detail/GroupDetailFragment.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/community/group/detail/GroupDetailFragment.kt
@@ -25,10 +25,22 @@ internal class GroupDetailFragment :
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        initViews()
+        observeState()
+    }
+
+    private fun initViews() {
+        binding.viewModel = viewModel
         setupMenu()
-        handleEvent()
-        setBindingData()
         setNotificationAdapter()
+    }
+
+    private fun observeState() {
+        viewLifecycleOwner.repeatWhenUiStarted {
+            viewModel.eventFlow.collect { event ->
+                handleEvent(event)
+            }
+        }
     }
 
     private fun setupMenu() {
@@ -77,66 +89,58 @@ internal class GroupDetailFragment :
         }
     }
 
-    private fun handleEvent() {
-        viewLifecycleOwner.repeatWhenUiStarted {
-            viewModel.eventFlow.collect { event ->
-                when (event) {
-                    Event.RecruitButtonClick -> {
-                        Snackbar.make(
-                            binding.root,
-                            getString(R.string.text_check_recruit),
-                            Snackbar.LENGTH_SHORT
-                        ).setAction(R.string.text_recruit) {
-                            viewModel.onRecruitSnackBarButtonClick()
-                        }.show()
-                    }
-                    is Event.RecruitSnackBarButtonClick -> {
-                        if (event.isSuccess) {
-                            Snackbar.make(
-                                binding.root,
-                                getString(R.string.text_recruit_success),
-                                Snackbar.LENGTH_SHORT
-                            ).show()
-                        } else {
-                            Snackbar.make(
-                                binding.root,
-                                getString(R.string.text_recruit_fail),
-                                Snackbar.LENGTH_SHORT
-                            ).show()
-                        }
-                    }
-                    Event.ExitGroupButtonClick -> {
-                        Snackbar.make(
-                            binding.root,
-                            getString(R.string.text_check_exit_group),
-                            Snackbar.LENGTH_SHORT
-                        ).setAction(getString(R.string.text_exit_group)) {
-                            viewModel.onExitGroupSnackBarButtonClick()
-                        }.show()
-                    }
-                    is Event.ExitGroupSnackBarButtonClick -> {
-                        if (event.isSuccess) {
-                            Snackbar.make(
-                                binding.root,
-                                getString(R.string.text_exit_group_success),
-                                Snackbar.LENGTH_SHORT
-                            ).show()
-                            findNavController().popBackStack()
-                        } else {
-                            Snackbar.make(
-                                binding.root,
-                                getString(R.string.text_exit_group_fail),
-                                Snackbar.LENGTH_SHORT
-                            ).show()
-                        }
-                    }
+    private fun handleEvent(event: Event) {
+        when (event) {
+            Event.RecruitButtonClick -> {
+                Snackbar.make(
+                    binding.root,
+                    getString(R.string.text_check_recruit),
+                    Snackbar.LENGTH_SHORT
+                ).setAction(R.string.text_recruit) {
+                    viewModel.onRecruitSnackBarButtonClick()
+                }.show()
+            }
+            is Event.RecruitSnackBarButtonClick -> {
+                if (event.isSuccess) {
+                    Snackbar.make(
+                        binding.root,
+                        getString(R.string.text_recruit_success),
+                        Snackbar.LENGTH_SHORT
+                    ).show()
+                } else {
+                    Snackbar.make(
+                        binding.root,
+                        getString(R.string.text_recruit_fail),
+                        Snackbar.LENGTH_SHORT
+                    ).show()
+                }
+            }
+            Event.ExitGroupButtonClick -> {
+                Snackbar.make(
+                    binding.root,
+                    getString(R.string.text_check_exit_group),
+                    Snackbar.LENGTH_SHORT
+                ).setAction(getString(R.string.text_exit_group)) {
+                    viewModel.onExitGroupSnackBarButtonClick()
+                }.show()
+            }
+            is Event.ExitGroupSnackBarButtonClick -> {
+                if (event.isSuccess) {
+                    Snackbar.make(
+                        binding.root,
+                        getString(R.string.text_exit_group_success),
+                        Snackbar.LENGTH_SHORT
+                    ).show()
+                    findNavController().popBackStack()
+                } else {
+                    Snackbar.make(
+                        binding.root,
+                        getString(R.string.text_exit_group_fail),
+                        Snackbar.LENGTH_SHORT
+                    ).show()
                 }
             }
         }
-    }
-
-    private fun setBindingData() {
-        binding.viewModel = viewModel
     }
 
     private fun setNotificationAdapter() {

--- a/presentation/src/main/java/com/whyranoid/presentation/community/group/detail/GroupDetailViewModel.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/community/group/detail/GroupDetailViewModel.kt
@@ -74,7 +74,7 @@ class GroupDetailViewModel @Inject constructor(
                     .sortedBy { notification ->
                         when (notification) {
                             is StartNotification -> notification.startedAt
-                            is FinishNotification -> notification.runningHistory.startedAt
+                            is FinishNotification -> notification.runningHistory.finishedAt
                         }
                     }
         }.launchIn(viewModelScope)


### PR DESCRIPTION
## 😎 작업 내용
- 게시판, 내가 쓴 글 탭에서 shimmer가 보이도록 변경
  - 내 그룹 탭의 로직도 살짝 변경 
- 일부 프레그먼트들 initViews, observeState를 사용하도록 변경 
- 운동 종료 알림 정렬이 잘못되었던 버그 수정

## 🧐 변경된 내용
- 게시판, 내가 쓴 글 탭에서 shimmer가 보이도록 변경
  - 내 그룹 탭의 로직도 살짝 변경 
- 일부 프레그먼트들 initViews, observeState를 사용하도록 변경 
- 운동 종료 알림 정렬이 잘못되었던 버그 수정

## 🥳 동작 화면
- shimmer!!
![shimmer](https://user-images.githubusercontent.com/90144041/205953145-e1467527-90ea-43cb-817b-21fa63e1967d.gif)

## 🤯 이슈 번호
- 이슈 없음
