### PR TITLE
컴포즈로 만든 RulePicker 레이아웃 변경

### DIFF
--- a/domain/src/main/java/com/whyranoid/domain/model/Rule.kt
+++ b/domain/src/main/java/com/whyranoid/domain/model/Rule.kt
@@ -6,7 +6,7 @@ data class Rule(
     val minute: Int
 ) {
     override fun toString(): String {
-        return "${dayOfWeek.dayResId}-$hour-$minute"
+        return "${dayOfWeek.dayResId}요일${hour}시${minute}분"
     }
 }
 

--- a/presentation/src/main/java/com/whyranoid/presentation/compose/DropDownMenu.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/compose/DropDownMenu.kt
@@ -11,13 +11,15 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringArrayResource
+import com.whyranoid.presentation.R
 
 @Composable
 fun DateDropDownMenu(
     selectedDate: String,
     onDateSelected: (String) -> Unit
 ) {
-    val dateList = "월 화 수 목 금 토 일".split(" ").toList()
+    val dateList = stringArrayResource(id = R.array.rule_date_array)
     var isDropDownMenuExpanded by remember { mutableStateOf(false) }
     Button(
         onClick = { isDropDownMenuExpanded = true }
@@ -47,8 +49,7 @@ fun HourDropDownMenu(
     selectedHour: String,
     onHourSelected: (String) -> Unit
 ) {
-    val hourList =
-        "0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23".split(" ").toList()
+    val hourList = stringArrayResource(id = R.array.rule_hour_array)
     var isDropDownMenuExpanded by remember { mutableStateOf(false) }
     Button(
         onClick = { isDropDownMenuExpanded = true }
@@ -78,8 +79,7 @@ fun MinuteDropDownMenu(
     selectedMinute: String,
     onMinuteSelected: (String) -> Unit
 ) {
-    val minuteList =
-        "0 5 10 15 20 25 30 35 40 45 50 55 60".split(" ").toList()
+    val minuteList = stringArrayResource(id = R.array.rule_minute_array)
     var isDropDownMenuExpanded by remember { mutableStateOf(false) }
 
     Button(

--- a/presentation/src/main/java/com/whyranoid/presentation/compose/DropDownMenu.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/compose/DropDownMenu.kt
@@ -1,7 +1,11 @@
 package com.whyranoid.presentation.compose
 
-import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Button
+import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.DropdownMenu
 import androidx.compose.material.DropdownMenuItem
 import androidx.compose.material.Text
@@ -11,7 +15,10 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringArrayResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import com.whyranoid.presentation.R
 
 @Composable
@@ -19,17 +26,29 @@ fun DateDropDownMenu(
     selectedDate: String,
     onDateSelected: (String) -> Unit
 ) {
+    val dateText = stringResource(id = R.string.text_date)
     val dateList = stringArrayResource(id = R.array.rule_date_array)
     var isDropDownMenuExpanded by remember { mutableStateOf(false) }
     Button(
-        onClick = { isDropDownMenuExpanded = true }
+        onClick = { isDropDownMenuExpanded = true },
+        colors = ButtonDefaults
+            .outlinedButtonColors(
+                contentColor = colorResource(id = R.color.mogakrun_on_primary)
+            ),
+        shape = RoundedCornerShape(30),
+        elevation = ButtonDefaults.elevation(
+            defaultElevation = 2.dp,
+            pressedElevation = 4.dp,
+            disabledElevation = 0.dp
+        )
     ) {
-        Text(text = selectedDate)
+        Text(text = selectedDate + dateText)
     }
 
     DropdownMenu(
         modifier = Modifier
-            .wrapContentSize(),
+            .wrapContentWidth()
+            .wrapContentHeight(),
         expanded = isDropDownMenuExpanded,
         onDismissRequest = { isDropDownMenuExpanded = false }
     ) {
@@ -38,7 +57,7 @@ fun DateDropDownMenu(
                 onDateSelected(date)
                 isDropDownMenuExpanded = false
             }) {
-                Text(text = date)
+                Text(text = date + dateText)
             }
         }
     }
@@ -49,17 +68,29 @@ fun HourDropDownMenu(
     selectedHour: String,
     onHourSelected: (String) -> Unit
 ) {
+    val hourText = stringResource(id = R.string.text_hour)
     val hourList = stringArrayResource(id = R.array.rule_hour_array)
     var isDropDownMenuExpanded by remember { mutableStateOf(false) }
     Button(
-        onClick = { isDropDownMenuExpanded = true }
+        onClick = { isDropDownMenuExpanded = true },
+        colors = ButtonDefaults
+            .outlinedButtonColors(
+                contentColor = colorResource(id = R.color.mogakrun_on_primary)
+            ),
+        shape = RoundedCornerShape(30),
+        elevation = ButtonDefaults.elevation(
+            defaultElevation = 2.dp,
+            pressedElevation = 4.dp,
+            disabledElevation = 0.dp
+        )
     ) {
-        Text(text = selectedHour)
+        Text(text = selectedHour + hourText)
     }
 
     DropdownMenu(
         modifier = Modifier
-            .wrapContentSize(),
+            .wrapContentWidth()
+            .height(500.dp),
         expanded = isDropDownMenuExpanded,
         onDismissRequest = { isDropDownMenuExpanded = false }
     ) {
@@ -68,7 +99,7 @@ fun HourDropDownMenu(
                 onHourSelected(hour)
                 isDropDownMenuExpanded = false
             }) {
-                Text(text = hour)
+                Text(text = hour + hourText)
             }
         }
     }
@@ -79,18 +110,30 @@ fun MinuteDropDownMenu(
     selectedMinute: String,
     onMinuteSelected: (String) -> Unit
 ) {
+    val minuteText = stringResource(id = R.string.text_minute)
     val minuteList = stringArrayResource(id = R.array.rule_minute_array)
     var isDropDownMenuExpanded by remember { mutableStateOf(false) }
 
     Button(
-        onClick = { isDropDownMenuExpanded = true }
+        onClick = { isDropDownMenuExpanded = true },
+        colors = ButtonDefaults
+            .outlinedButtonColors(
+                contentColor = colorResource(id = R.color.mogakrun_on_primary)
+            ),
+        shape = RoundedCornerShape(30),
+        elevation = ButtonDefaults.elevation(
+            defaultElevation = 2.dp,
+            pressedElevation = 4.dp,
+            disabledElevation = 0.dp
+        )
     ) {
-        Text(text = selectedMinute)
+        Text(text = selectedMinute + minuteText)
     }
 
     DropdownMenu(
         modifier = Modifier
-            .wrapContentSize(),
+            .wrapContentWidth()
+            .height(500.dp),
         expanded = isDropDownMenuExpanded,
         onDismissRequest = { isDropDownMenuExpanded = false }
     ) {
@@ -99,7 +142,7 @@ fun MinuteDropDownMenu(
                 onMinuteSelected(minute)
                 isDropDownMenuExpanded = false
             }) {
-                Text(text = minute)
+                Text(text = minute + minuteText)
             }
         }
     }

--- a/presentation/src/main/java/com/whyranoid/presentation/compose/RulePicker.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/compose/RulePicker.kt
@@ -1,8 +1,12 @@
 package com.whyranoid.presentation.compose
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.AlertDialog
 import androidx.compose.material.Text
 import androidx.compose.material.TextButton
@@ -11,8 +15,14 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight.Companion.Bold
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.whyranoid.presentation.R
 import com.whyranoid.presentation.community.group.create.CreateGroupViewModel
 
 @Composable
@@ -20,29 +30,52 @@ fun RulePicker(
     declarationDialogState: Boolean,
     viewModel: CreateGroupViewModel
 ) {
-    var selectedDate by remember { mutableStateOf("요일") }
-    var selectedHour by remember { mutableStateOf("시간") }
-    var selectedMinute by remember { mutableStateOf("분") }
+    val emptyText = stringResource(id = R.string.text_empty)
+    val confirmText = stringResource(id = R.string.text_confirm)
+    val cancelText = stringResource(id = R.string.text_cancel)
+    val dialogTitleText = stringResource(id = R.string.text_rule_picker_title)
+
+    var selectedDate by remember { mutableStateOf(emptyText) }
+    var selectedHour by remember { mutableStateOf(emptyText) }
+    var selectedMinute by remember { mutableStateOf(emptyText) }
+
     if (declarationDialogState) {
         AlertDialog(
             onDismissRequest = {
                 viewModel.onDialogDismiss()
             },
             title = {
-                Text(text = "요일 및 시간을 골라주세요!!")
             },
             text = {
-                Column {
-                    DateDropDownMenu(selectedDate) { date ->
-                        selectedDate = date
-                    }
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(8.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Text(
+                        text = dialogTitleText,
+                        color = colorResource(id = R.color.mogakrun_onBackground),
+                        fontWeight = Bold,
+                        fontSize = 20.sp
+                    )
                     Spacer(modifier = Modifier.padding(bottom = 10.dp))
-                    HourDropDownMenu(selectedHour) { hour ->
-                        selectedHour = hour
-                    }
-                    Spacer(modifier = Modifier.padding(bottom = 10.dp))
-                    MinuteDropDownMenu(selectedMinute) { minute ->
-                        selectedMinute = minute
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically
+
+                    ) {
+                        DateDropDownMenu(selectedDate) { date ->
+                            selectedDate = date
+                        }
+                        HourDropDownMenu(selectedHour) { hour ->
+                            selectedHour = hour
+                        }
+                        MinuteDropDownMenu(selectedMinute) { minute ->
+                            selectedMinute = minute
+                        }
                     }
                 }
             },
@@ -50,26 +83,36 @@ fun RulePicker(
                 TextButton(
                     onClick = {
                         viewModel.onDialogConfirm(selectedDate, selectedHour, selectedMinute)
-                        selectedDate = "요일"
-                        selectedHour = "시간"
-                        selectedMinute = "분"
+                        selectedDate = emptyText
+                        selectedHour = emptyText
+                        selectedMinute = emptyText
                     }
                 ) {
-                    Text("확인")
+                    Text(
+                        text = confirmText,
+                        color = colorResource(id = R.color.mogakrun_on_primary)
+                    )
                 }
             },
             dismissButton = {
                 TextButton(
                     onClick = {
                         viewModel.onDialogDismiss()
-                        selectedDate = "요일"
-                        selectedHour = "시간"
-                        selectedMinute = "분"
+                        selectedDate = emptyText
+                        selectedHour = emptyText
+                        selectedMinute = emptyText
                     }
+
                 ) {
-                    Text("취소")
+                    Text(
+                        text = cancelText,
+                        color = colorResource(id = R.color.mogakrun_on_primary)
+                    )
                 }
-            }
+            },
+            backgroundColor = colorResource(id = R.color.mogakrun_background),
+            contentColor = colorResource(id = R.color.mogakrun_on_primary),
+            shape = RoundedCornerShape(10)
         )
     }
 }

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -2,6 +2,8 @@
 
     <string name="app_name">MoGakRun</string>
 
+    <string name="text_empty" />
+
     <!-- 바텀네비게이션 -->
     <string name="bottom_navigation_menu_community">커뮤니티</string>
     <string name="bottom_navigation_menu_running">러닝</string>
@@ -178,5 +180,12 @@
         <item>50</item>
         <item>55</item>
     </string-array>
+
+    <!-- 규칙 생성 다이어로그-->
+    <string name="text_date">요일</string>
+    <string name="text_hour">시</string>
+    <string name="text_minute">분</string>
+    <string name="text_confirm">확인</string>
+    <string name="text_rule_picker_title">요일 및 시간을 골라주세요!!</string>
 
 </resources>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -115,7 +115,7 @@
     <string name="running_map_location_button">🎯</string>
     <string name="running_start_progress_description">러닝 시작을 기다리고 있어요</string>
 
-    <!--라닝 종료 화면-->
+    <!-- 러닝 종료 화면 -->
     <string name="running_finish_tool_bar">러닝 종료</string>
     <string name="running_finish_positive_btn">자랑할래요</string>
     <string name="running_finish_negative_btn">괜찮아요</string>
@@ -123,5 +123,60 @@
     <string name="running_finish_snackbar_content">러닝을 종료하시겠습니까?</string>
     <string name="running_finish_snackbar_action">종료하기</string>
     <string name="running_start_error_message">러닝 도중 에러가 발생했어요! 죄송해요..</string>
+
+    <!-- 규칙 생성 시 요일 -->
+    <string-array name="rule_date_array">
+        <item>월</item>
+        <item>화</item>
+        <item>수</item>
+        <item>목</item>
+        <item>금</item>
+        <item>토</item>
+        <item>일</item>
+    </string-array>
+
+    <!-- 규칙 생성 시 시간 -->
+    <string-array name="rule_hour_array">
+        <item>0</item>
+        <item>1</item>
+        <item>2</item>
+        <item>3</item>
+        <item>4</item>
+        <item>5</item>
+        <item>6</item>
+        <item>7</item>
+        <item>8</item>
+        <item>9</item>
+        <item>10</item>
+        <item>11</item>
+        <item>12</item>
+        <item>13</item>
+        <item>14</item>
+        <item>15</item>
+        <item>16</item>
+        <item>17</item>
+        <item>18</item>
+        <item>19</item>
+        <item>20</item>
+        <item>21</item>
+        <item>22</item>
+        <item>23</item>
+    </string-array>
+
+    <!-- 규칙 생성 시 분 -->
+    <string-array name="rule_minute_array">
+        <item>0</item>
+        <item>5</item>
+        <item>10</item>
+        <item>15</item>
+        <item>20</item>
+        <item>25</item>
+        <item>30</item>
+        <item>35</item>
+        <item>40</item>
+        <item>45</item>
+        <item>50</item>
+        <item>55</item>
+    </string-array>
 
 </resources>


### PR DESCRIPTION
## 😎 작업 내용
- RulePicker의 레이아웃 MogakRun 테마에 맞게 변경

## 🧐 변경된 내용
- RulePicker의 전체적인 레이아웃 변경
- RulePicker와 DropDownMenu에 있는 hard String들 String Resource로 분리

## 🥳 동작 화면
- 기존의 다이어로그 화면
<img width="420" alt="Screenshot 2022-12-07 at 3 44 55 PM" src="https://user-images.githubusercontent.com/90144041/206107862-553915d6-ff2f-4322-a786-b197fd246e67.png">

- 수정된 다이어로그 화면
<img width="420" alt="Screenshot 2022-12-07 at 3 45 52 PM" src="https://user-images.githubusercontent.com/90144041/206108019-1de2e204-dc9f-41bf-9f9d-e7bdc5f644d6.png">

## 🤯 이슈 번호
- 이슈 없음
