### PR TITLE
앱을 삭제했다가 다시 깔거나 다른 디바이스에서 로그인할 때 정보가 유지되도록 수정

### DIFF
--- a/data/src/main/java/com/whyranoid/data/account/RunningHistoryDao.kt
+++ b/data/src/main/java/com/whyranoid/data/account/RunningHistoryDao.kt
@@ -9,8 +9,7 @@ import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface RunningHistoryDao {
-    // TODO 일단 쓰기, 읽기만 해놨습니다~
-    @Insert(onConflict = OnConflictStrategy.ABORT)
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun addRunningHistory(runningHistory: RunningHistoryEntity)
 
     @Query("SELECT * FROM running_history ORDER BY started_at ASC")

--- a/data/src/main/java/com/whyranoid/data/account/RunningHistoryRemoteDataSource.kt
+++ b/data/src/main/java/com/whyranoid/data/account/RunningHistoryRemoteDataSource.kt
@@ -4,5 +4,5 @@ import com.whyranoid.domain.model.RunningHistory
 
 interface RunningHistoryRemoteDataSource {
 
-    suspend fun uploadRunningHistory(runningHistory: RunningHistory): Result<Boolean>
+    suspend fun uploadRunningHistory(uid: String, runningHistory: RunningHistory): Result<Boolean>
 }

--- a/data/src/main/java/com/whyranoid/data/account/RunningHistoryRemoteDataSourceImpl.kt
+++ b/data/src/main/java/com/whyranoid/data/account/RunningHistoryRemoteDataSourceImpl.kt
@@ -11,8 +11,8 @@ import javax.inject.Inject
 
 class RunningHistoryRemoteDataSourceImpl @Inject constructor(private val firebaseDB: FirebaseFirestore) :
     RunningHistoryRemoteDataSource {
-    override suspend fun uploadRunningHistory(runningHistory: RunningHistory): Result<Boolean> {
-        val runningHistoryResponse = runningHistory.toRunningHistoryResponse()
+    override suspend fun uploadRunningHistory(uid: String, runningHistory: RunningHistory): Result<Boolean> {
+        val runningHistoryResponse = runningHistory.toRunningHistoryResponse(uid)
         var uploadSuccess = false
 
         return runCatching {

--- a/data/src/main/java/com/whyranoid/data/account/RunningHistoryRepositoryImpl.kt
+++ b/data/src/main/java/com/whyranoid/data/account/RunningHistoryRepositoryImpl.kt
@@ -38,7 +38,7 @@ class RunningHistoryRepositoryImpl @Inject constructor(
         )
     }
 
-    override suspend fun uploadRunningHistory(runningHistory: RunningHistory): Result<Boolean> {
-        return runningHistoryRemoteDataSource.uploadRunningHistory(runningHistory)
+    override suspend fun uploadRunningHistory(uid: String, runningHistory: RunningHistory): Result<Boolean> {
+        return runningHistoryRemoteDataSource.uploadRunningHistory(uid, runningHistory)
     }
 }

--- a/data/src/main/java/com/whyranoid/data/model/RunningHistoryResponse.kt
+++ b/data/src/main/java/com/whyranoid/data/model/RunningHistoryResponse.kt
@@ -3,6 +3,7 @@ package com.whyranoid.data.model
 import com.whyranoid.domain.model.RunningHistory
 
 data class RunningHistoryResponse(
+    val uid: String = "",
     val historyId: String = "",
     val startedAt: Long = 0L,
     val finishedAt: Long = 0L,
@@ -11,8 +12,9 @@ data class RunningHistoryResponse(
     val totalDistance: Double = 0.0
 )
 
-fun RunningHistory.toRunningHistoryResponse() =
+fun RunningHistory.toRunningHistoryResponse(uid: String) =
     RunningHistoryResponse(
+        uid = uid,
         historyId = historyId,
         startedAt = startedAt,
         finishedAt = finishedAt,

--- a/data/src/main/java/com/whyranoid/data/model/RunningHistoryResponse.kt
+++ b/data/src/main/java/com/whyranoid/data/model/RunningHistoryResponse.kt
@@ -22,3 +22,13 @@ fun RunningHistory.toRunningHistoryResponse(uid: String) =
         pace = pace,
         totalDistance = totalDistance
     )
+
+fun RunningHistoryResponse.toRunningHistoryEntity() =
+    RunningHistoryEntity(
+        historyId = historyId,
+        startedAt = startedAt,
+        finishedAt = finishedAt,
+        totalRunningTime = totalRunningTime,
+        pace = pace,
+        totalDistance = totalDistance
+    )

--- a/domain/src/main/java/com/whyranoid/domain/repository/RunningHistoryRepository.kt
+++ b/domain/src/main/java/com/whyranoid/domain/repository/RunningHistoryRepository.kt
@@ -21,5 +21,5 @@ interface RunningHistoryRepository {
         totalDistance: Double
     ): Result<RunningHistory>
 
-    suspend fun uploadRunningHistory(runningHistory: RunningHistory): Result<Boolean>
+    suspend fun uploadRunningHistory(uid: String, runningHistory: RunningHistory): Result<Boolean>
 }

--- a/domain/src/main/java/com/whyranoid/domain/usecase/FinishRunningUseCase.kt
+++ b/domain/src/main/java/com/whyranoid/domain/usecase/FinishRunningUseCase.kt
@@ -19,7 +19,7 @@ class FinishRunningUseCase @Inject constructor(
         runnerRepository.finishRunning(uid)
 
         if (runningHistory != null) {
-            val uploadResult = runningHistoryRepository.uploadRunningHistory(runningHistory)
+            val uploadResult = runningHistoryRepository.uploadRunningHistory(uid, runningHistory)
 
             if (uploadResult.isFailure) {
                 return false

--- a/signin/src/main/java/com/whyranoid/RestoreRunningHistoryDataUseCase.kt
+++ b/signin/src/main/java/com/whyranoid/RestoreRunningHistoryDataUseCase.kt
@@ -1,0 +1,9 @@
+package com.whyranoid
+
+import javax.inject.Inject
+
+class RestoreRunningHistoryDataUseCase @Inject constructor(private val signInRepository: SignInRepository) {
+    suspend operator fun invoke(uid: String): Result<Boolean> {
+        return signInRepository.restoreRunningHistoryData(uid)
+    }
+}

--- a/signin/src/main/java/com/whyranoid/SignInDataSource.kt
+++ b/signin/src/main/java/com/whyranoid/SignInDataSource.kt
@@ -2,4 +2,5 @@ package com.whyranoid
 
 interface SignInDataSource {
     suspend fun saveLogInUserInfo(userInfo: SignInUserInfo): Boolean
+    suspend fun restoreRunningHistoryData(uid: String): Result<Boolean>
 }

--- a/signin/src/main/java/com/whyranoid/SignInDataSourceImpl.kt
+++ b/signin/src/main/java/com/whyranoid/SignInDataSourceImpl.kt
@@ -5,12 +5,17 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import com.google.firebase.firestore.FirebaseFirestore
+import com.whyranoid.data.account.RunningHistoryDao
+import com.whyranoid.data.model.RunningHistoryResponse
 import com.whyranoid.data.model.UserResponse
+import com.whyranoid.data.model.toRunningHistoryEntity
+import kotlinx.coroutines.tasks.await
 import javax.inject.Inject
 
 class SignInDataSourceImpl @Inject constructor(
     private val dataStoreDb: DataStore<Preferences>,
-    private val fireBaseDb: FirebaseFirestore
+    private val fireBaseDb: FirebaseFirestore,
+    private val runningHistoryDao: RunningHistoryDao
 ) : SignInDataSource {
 
     private object PreferenceKeys {
@@ -39,6 +44,14 @@ class SignInDataSourceImpl @Inject constructor(
             )
 
         return true
+    }
+
+    override suspend fun restoreRunningHistoryData(uid: String): Result<Boolean> = runCatching {
+        val runningHistoryData = fireBaseDb.collection("RunningHistory").whereEqualTo("uid", uid).get().await()
+        runningHistoryData.forEach { runningHistory ->
+            runningHistoryDao.addRunningHistory(runningHistory.toObject(RunningHistoryResponse::class.java).toRunningHistoryEntity())
+        }
+        true
     }
 
     companion object {

--- a/signin/src/main/java/com/whyranoid/SignInDataSourceImpl.kt
+++ b/signin/src/main/java/com/whyranoid/SignInDataSourceImpl.kt
@@ -26,30 +26,48 @@ class SignInDataSourceImpl @Inject constructor(
     }
 
     override suspend fun saveLogInUserInfo(userInfo: SignInUserInfo): Boolean {
-        dataStoreDb.edit { preferences ->
-            preferences[PreferenceKeys.uid] = userInfo.uid
-            preferences[PreferenceKeys.email] = userInfo.email ?: EMPTY_STRING
-            preferences[PreferenceKeys.nickName] = userInfo.nickName ?: EMPTY_STRING
-            preferences[PreferenceKeys.profileImgUri] = userInfo.profileImgUri ?: EMPTY_STRING
-        }
+        val existedUser =
+            fireBaseDb.collection(USER_COLLECTION_PATH).document(userInfo.uid).get().await()
+        val existedUserInfo = existedUser.toObject(UserResponse::class.java)
 
-        fireBaseDb.collection(USER_COLLECTION_PATH)
-            .document(userInfo.uid).set(
-                UserResponse(
-                    userInfo.uid,
-                    userInfo.nickName,
-                    userInfo.profileImgUri,
-                    emptyList()
+        if (existedUserInfo == null) {
+            dataStoreDb.edit { preferences ->
+                preferences[PreferenceKeys.uid] = userInfo.uid
+                preferences[PreferenceKeys.email] = userInfo.email ?: EMPTY_STRING
+                preferences[PreferenceKeys.nickName] = userInfo.nickName ?: EMPTY_STRING
+                preferences[PreferenceKeys.profileImgUri] = userInfo.profileImgUri ?: EMPTY_STRING
+            }
+
+            fireBaseDb.collection(USER_COLLECTION_PATH)
+                .document(userInfo.uid).set(
+                    UserResponse(
+                        userInfo.uid,
+                        userInfo.nickName,
+                        userInfo.profileImgUri,
+                        emptyList()
+                    )
                 )
-            )
+        } else {
+            dataStoreDb.edit { preferences ->
+                preferences[PreferenceKeys.uid] = existedUserInfo.uid
+                preferences[PreferenceKeys.email] = userInfo.email ?: EMPTY_STRING
+                preferences[PreferenceKeys.nickName] = existedUserInfo.name ?: EMPTY_STRING
+                preferences[PreferenceKeys.profileImgUri] =
+                    existedUserInfo.profileUrl ?: EMPTY_STRING
+            }
+        }
 
         return true
     }
 
     override suspend fun restoreRunningHistoryData(uid: String): Result<Boolean> = runCatching {
-        val runningHistoryData = fireBaseDb.collection("RunningHistory").whereEqualTo("uid", uid).get().await()
+        val runningHistoryData =
+            fireBaseDb.collection(RUNNING_HISTORY_COLLECTION_PATH).whereEqualTo(UID_KEY, uid).get()
+                .await()
         runningHistoryData.forEach { runningHistory ->
-            runningHistoryDao.addRunningHistory(runningHistory.toObject(RunningHistoryResponse::class.java).toRunningHistoryEntity())
+            runningHistoryDao.addRunningHistory(
+                runningHistory.toObject(RunningHistoryResponse::class.java).toRunningHistoryEntity()
+            )
         }
         true
     }
@@ -61,5 +79,6 @@ class SignInDataSourceImpl @Inject constructor(
         private const val PROFILE_IMG_URI = "profile_img_uri"
         private const val EMPTY_STRING = ""
         private const val USER_COLLECTION_PATH = "Users"
+        private const val RUNNING_HISTORY_COLLECTION_PATH = "RunningHistory"
     }
 }

--- a/signin/src/main/java/com/whyranoid/SignInRepository.kt
+++ b/signin/src/main/java/com/whyranoid/SignInRepository.kt
@@ -2,4 +2,5 @@ package com.whyranoid
 
 interface SignInRepository {
     suspend fun saveLogInUserInfo(userInfo: SignInUserInfo): Boolean
+    suspend fun restoreRunningHistoryData(uid: String): Result<Boolean>
 }

--- a/signin/src/main/java/com/whyranoid/SignInRepositoryImpl.kt
+++ b/signin/src/main/java/com/whyranoid/SignInRepositoryImpl.kt
@@ -8,4 +8,8 @@ class SignInRepositoryImpl @Inject constructor(private val signInDataSource: Sig
     override suspend fun saveLogInUserInfo(userInfo: SignInUserInfo): Boolean {
         return signInDataSource.saveLogInUserInfo(userInfo)
     }
+
+    override suspend fun restoreRunningHistoryData(uid: String): Result<Boolean> {
+        return signInDataSource.restoreRunningHistoryData(uid)
+    }
 }

--- a/signin/src/main/java/com/whyranoid/SignInViewModel.kt
+++ b/signin/src/main/java/com/whyranoid/SignInViewModel.kt
@@ -6,9 +6,14 @@ import javax.inject.Inject
 
 @HiltViewModel
 class SignInViewModel @Inject constructor(
-    private val saveLogInUserInfoUseCase: SaveLogInUserInfoUseCase
+    private val saveLogInUserInfoUseCase: SaveLogInUserInfoUseCase,
+    private val restoreRunningHistoryDataUseCase: RestoreRunningHistoryDataUseCase
 ) : ViewModel() {
     suspend fun saveUserInfo(userInfo: SignInUserInfo) {
         saveLogInUserInfoUseCase(userInfo)
+    }
+
+    suspend fun restoreRunningHistoryData(uid: String) {
+        restoreRunningHistoryDataUseCase(uid)
     }
 }

--- a/signin/src/main/java/com/whyranoid/signin/SignInActivity.kt
+++ b/signin/src/main/java/com/whyranoid/signin/SignInActivity.kt
@@ -126,6 +126,7 @@ class SignInActivity : AppCompatActivity() {
                 lifecycleScope.launch {
                     uid?.let { uid ->
                         viewModel.saveUserInfo(SignInUserInfo(uid, email, nickName, profileImgUri))
+                        viewModel.restoreRunningHistoryData(uid)
                     }
                 }
 


### PR DESCRIPTION
## 😎 작업 내용
- 앱을 삭제했다가 다시 깔거나 디바이스를 옮겨도 운동기록과 닉네임, 프로필 사진은 유지되도록 구현

## 🧐 변경된 내용
- 변경된 내용을 작성해주세요.

## 🥳 동작 화면
- 동작 화면 없음

## 🤯 이슈 번호
- 이슈 없음
