### PR TITLE
네트워트 연결 상태 Repository로 구현

### DIFF
--- a/data/src/main/AndroidManifest.xml
+++ b/data/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 </manifest>

--- a/data/src/main/java/com/whyranoid/data/di/ConnectionModule.kt
+++ b/data/src/main/java/com/whyranoid/data/di/ConnectionModule.kt
@@ -1,0 +1,22 @@
+package com.whyranoid.data.di
+
+import android.content.Context
+import com.whyranoid.data.running.NetworkRepositoryImpl
+import com.whyranoid.domain.repository.NetworkRepository
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+class ConnectionModule {
+
+    @Provides
+    @Singleton
+    fun provideNetworkRepository(@ApplicationContext context: Context): NetworkRepository {
+        return NetworkRepositoryImpl(context)
+    }
+}

--- a/data/src/main/java/com/whyranoid/data/running/NetworkRepositoryImpl.kt
+++ b/data/src/main/java/com/whyranoid/data/running/NetworkRepositoryImpl.kt
@@ -1,0 +1,78 @@
+package com.whyranoid.data.running
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.os.Build
+import com.whyranoid.domain.repository.NetworkRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class NetworkRepositoryImpl(private val context: Context) :
+    NetworkRepository {
+
+    private val _networkConnectionState = MutableStateFlow(getCurrentNetwork())
+    override fun getNetworkConnectionState() = _networkConnectionState.asStateFlow()
+
+    private val connectivityManager =
+        context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+
+    private val connectivityCallback = object : ConnectivityManager.NetworkCallback() {
+        override fun onAvailable(network: Network) {
+            emitNetworkConnectionState(true)
+        }
+
+        override fun onLost(network: Network) {
+            emitNetworkConnectionState(false)
+        }
+    }
+    private val connectivityReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context?, intent: Intent?) {
+            if (context != null && context.isConnected) {
+                emitNetworkConnectionState(true)
+            } else {
+                emitNetworkConnectionState(false)
+            }
+        }
+    }
+
+    override fun addNetworkConnectionCallback() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            connectivityManager.registerDefaultNetworkCallback(connectivityCallback)
+        } else {
+            context.registerReceiver(
+                connectivityReceiver,
+                IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION)
+            )
+        }
+    }
+
+    override fun removeNetworkConnectionCallback() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            connectivityManager.unregisterNetworkCallback(connectivityCallback)
+        } else {
+            context.unregisterReceiver(connectivityReceiver)
+        }
+    }
+
+    private fun getCurrentNetwork(): Boolean {
+        return try {
+            val networkCapabilities =
+                connectivityManager.getNetworkCapabilities(connectivityManager.activeNetwork)
+            networkCapabilities?.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) == true
+        } catch (e: Exception) {
+            false
+        }
+    }
+
+    private fun emitNetworkConnectionState(currentState: Boolean) {
+        _networkConnectionState.value = currentState
+    }
+}
+
+val Context.isConnected: Boolean
+    get() = (getSystemService(Context.CONNECTIVITY_SERVICE) as? ConnectivityManager)?.activeNetworkInfo?.isConnected == true

--- a/domain/src/main/java/com/whyranoid/domain/repository/NetworkRepository.kt
+++ b/domain/src/main/java/com/whyranoid/domain/repository/NetworkRepository.kt
@@ -1,0 +1,12 @@
+package com.whyranoid.domain.repository
+
+import kotlinx.coroutines.flow.StateFlow
+
+interface NetworkRepository {
+
+    fun getNetworkConnectionState(): StateFlow<Boolean>
+
+    fun addNetworkConnectionCallback()
+
+    fun removeNetworkConnectionCallback()
+}

--- a/presentation/src/main/java/com/whyranoid/presentation/community/runningpost/CreateRunningPostFragment.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/community/runningpost/CreateRunningPostFragment.kt
@@ -25,13 +25,20 @@ internal class CreateRunningPostFragment :
         observeState()
     }
 
+    override fun onDestroyView() {
+        viewModel.finishObservingNetworkState()
+        super.onDestroyView()
+    }
+
     private fun initViews() {
         binding.vm = viewModel
         binding.selectedRunningHistory = viewModel.selectedRunningHistory
+        binding.executePendingBindings()
         setUpMenu()
     }
 
     private fun observeState() {
+        viewModel.startObservingNetworkState()
         viewLifecycleOwner.repeatWhenUiStarted {
             viewModel.createPostState.collect { createPostState ->
                 when (createPostState) {

--- a/presentation/src/main/java/com/whyranoid/presentation/runningstart/RunningStartFragment.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/runningstart/RunningStartFragment.kt
@@ -65,8 +65,15 @@ internal class RunningStartFragment :
         observeState()
     }
 
+    override fun onDestroyView() {
+        viewModel.finishObservingNetworkState()
+        super.onDestroyView()
+    }
+
     private fun initViews() {
         binding.vm = viewModel
+        binding.executePendingBindings()
+
         if ((viewModel.runningDataManager.runningState.value is RunningState.NotRunning).not()) {
             runningActivityLauncher.launch(
                 Intent(
@@ -78,6 +85,7 @@ internal class RunningStartFragment :
     }
 
     private fun observeState() {
+        viewModel.startObservingNetworkState()
         viewLifecycleOwner.repeatWhenUiStarted {
             viewModel.runnerCount.collect { runnerCount ->
                 binding.tvRunnerCountNumber.text = runnerCount.toString()

--- a/presentation/src/main/java/com/whyranoid/presentation/runningstart/RunningStartViewModel.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/runningstart/RunningStartViewModel.kt
@@ -4,22 +4,34 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.whyranoid.domain.usecase.GetRunnerCountUseCase
 import com.whyranoid.presentation.util.networkconnection.NetworkConnectionStateHolder
+import com.whyranoid.presentation.util.networkconnection.NetworkState
 import com.whyranoid.runningdata.RunningDataManager
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class RunningStartViewModel @Inject constructor(
     getRunnerCountUseCase: GetRunnerCountUseCase,
-    networkConnectionStateHolder: NetworkConnectionStateHolder
+    private val networkConnectionStateHolder: NetworkConnectionStateHolder
 ) : ViewModel() {
 
     val runningDataManager = RunningDataManager.getInstance()
 
-    val networkState = networkConnectionStateHolder.networkState
+    @OptIn(FlowPreview::class)
+    val networkState = networkConnectionStateHolder.networkConnectionState
+        .debounce(500)
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = NetworkState.UnInitialized
+        )
 
     val runnerCount = getRunnerCountUseCase()
 
@@ -36,5 +48,13 @@ class RunningStartViewModel @Inject constructor(
         viewModelScope.launch {
             _eventFlow.emit(event)
         }
+    }
+
+    fun startObservingNetworkState() {
+        networkConnectionStateHolder.startObservingState()
+    }
+
+    fun finishObservingNetworkState() {
+        networkConnectionStateHolder.finishObservingState()
     }
 }

--- a/presentation/src/main/java/com/whyranoid/presentation/runningstart/RunningStartViewModel.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/runningstart/RunningStartViewModel.kt
@@ -2,8 +2,8 @@ package com.whyranoid.presentation.runningstart
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.whyranoid.domain.repository.NetworkRepository
 import com.whyranoid.domain.usecase.GetRunnerCountUseCase
-import com.whyranoid.presentation.util.networkconnection.NetworkConnectionStateHolder
 import com.whyranoid.presentation.util.networkconnection.NetworkState
 import com.whyranoid.runningdata.RunningDataManager
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -12,6 +12,7 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -19,13 +20,16 @@ import javax.inject.Inject
 @HiltViewModel
 class RunningStartViewModel @Inject constructor(
     getRunnerCountUseCase: GetRunnerCountUseCase,
-    private val networkConnectionStateHolder: NetworkConnectionStateHolder
+    private val networkRepository: NetworkRepository
 ) : ViewModel() {
 
     val runningDataManager = RunningDataManager.getInstance()
 
     @OptIn(FlowPreview::class)
-    val networkState = networkConnectionStateHolder.networkConnectionState
+    val networkState = networkRepository.getNetworkConnectionState()
+        .map { isConnected ->
+            if (isConnected) NetworkState.Connection else NetworkState.DisConnection
+        }
         .debounce(500)
         .stateIn(
             scope = viewModelScope,
@@ -51,10 +55,10 @@ class RunningStartViewModel @Inject constructor(
     }
 
     fun startObservingNetworkState() {
-        networkConnectionStateHolder.startObservingState()
+        networkRepository.addNetworkConnectionCallback()
     }
 
     fun finishObservingNetworkState() {
-        networkConnectionStateHolder.finishObservingState()
+        networkRepository.removeNetworkConnectionCallback()
     }
 }

--- a/presentation/src/main/java/com/whyranoid/presentation/util/networkconnection/NetworkConnectionStateHolder.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/util/networkconnection/NetworkConnectionStateHolder.kt
@@ -5,27 +5,68 @@ import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import android.net.ConnectivityManager
+import android.net.ConnectivityManager.NetworkCallback
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.os.Build
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
 
-class NetworkConnectionStateHolder(context: Context) {
+class NetworkConnectionStateHolder(private val context: Context) {
 
-    private val _networkState = MutableStateFlow<NetworkState>(NetworkState.UnInitialized)
-    val networkState: StateFlow<NetworkState> get() = _networkState.asStateFlow()
+    private val _networkConnectionState = MutableStateFlow<NetworkState>(NetworkState.UnInitialized)
+    val networkConnectionState: StateFlow<NetworkState> = _networkConnectionState
 
-    private val networkReceiver = object : BroadcastReceiver() {
-        override fun onReceive(context: Context, intent: Intent) {
-            _networkState.value =
-                if (context.isConnected) NetworkState.Connection else NetworkState.DisConnection
+    private val connectivityManager =
+        context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+    private val connectivityCallback = object : NetworkCallback() {
+        override fun onAvailable(network: Network) {
+            emitNetworkConnectionState(NetworkState.Connection)
+        }
+
+        override fun onLost(network: Network) {
+            emitNetworkConnectionState(NetworkState.DisConnection)
+        }
+    }
+    private val connectivityReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context?, intent: Intent?) {
+            if (context != null && context.isConnected) {
+                emitNetworkConnectionState(NetworkState.Connection)
+            } else {
+                emitNetworkConnectionState(NetworkState.DisConnection)
+            }
         }
     }
 
-    init {
-        context.registerReceiver(
-            networkReceiver,
-            IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION)
-        )
+    fun startObservingState() {
+        val networkCapabilities =
+            connectivityManager.getNetworkCapabilities(connectivityManager.activeNetwork)
+        if (networkCapabilities?.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) == true) {
+            emitNetworkConnectionState(NetworkState.Connection)
+        } else {
+            emitNetworkConnectionState(NetworkState.DisConnection)
+        }
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            connectivityManager.registerDefaultNetworkCallback(connectivityCallback)
+        } else {
+            context.registerReceiver(
+                connectivityReceiver,
+                IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION)
+            )
+        }
+    }
+
+    fun finishObservingState() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            connectivityManager.unregisterNetworkCallback(connectivityCallback)
+        } else {
+            context.unregisterReceiver(connectivityReceiver)
+        }
+    }
+
+    private fun emitNetworkConnectionState(currentState: NetworkState) {
+        _networkConnectionState.value = currentState
     }
 }
 

--- a/presentation/src/main/res/layout/fragment_create_running_post.xml
+++ b/presentation/src/main/res/layout/fragment_create_running_post.xml
@@ -18,6 +18,19 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
+        <TextView
+            android:id="@+id/tv_network_connection"
+            networkConnectionVisibility="@{vm.networkState}"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@color/gray"
+            android:gravity="center"
+            android:padding="4dp"
+            android:text="@string/network_connection_alert"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/app_bar" />
+
         <com.google.android.material.appbar.AppBarLayout
             android:id="@+id/app_bar"
             android:layout_width="match_parent"
@@ -42,7 +55,7 @@
             android:layout_height="wrap_content"
             android:text="@string/community_label_running_history"
             android:textAppearance="@style/MoGakRunText.Bold.Medium"
-            app:layout_constraintTop_toBottomOf="@id/app_bar"
+            app:layout_constraintTop_toBottomOf="@id/tv_network_connection"
             app:layout_constraintStart_toStartOf="parent"
             android:layout_marginTop="20dp"
             android:layout_marginStart="16dp"


### PR DESCRIPTION
## 😎 작업 내용
- 안드로이드 아키텍처 권장사항을 따르기 위해 네트워크 연결 상태를 repository를 구현하여 노출시킴

## 🧐 변경된 내용
- 네트워크 연결 상태 로직에서 deprecated된 메소드 버전 분기 처리
- domain 모듈에 NetworkRepository 생성

## 🥳 동작 화면

| 러닝 시작 화면 | 인증글 작성 화면 |
| ---------------- | ------------------- |
| <img src="https://user-images.githubusercontent.com/44428543/206276391-3cc53bf7-648c-445d-b627-fbbbf5728364.gif" height=700 /> | <img src="https://user-images.githubusercontent.com/44428543/206276534-5000228e-32c9-425b-9689-0877fc8da0f4.gif" height=700 /> | 

## 🤯 이슈 번호
- 이슈 없음
