### PR TITLE
snack bar 확장함수 추가, 캘린더 버그 수정 및 연도 표시 추가

### DIFF
--- a/presentation/src/main/java/com/whyranoid/presentation/community/CommunityItemFragment.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/community/CommunityItemFragment.kt
@@ -7,11 +7,11 @@ import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import androidx.paging.LoadState
-import com.google.android.material.snackbar.Snackbar
 import com.whyranoid.presentation.R
 import com.whyranoid.presentation.base.BaseFragment
 import com.whyranoid.presentation.databinding.FragmentCommunityItemBinding
 import com.whyranoid.presentation.util.getSerializableData
+import com.whyranoid.presentation.util.makeSnackBar
 import com.whyranoid.presentation.util.repeatWhenUiStarted
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
@@ -73,34 +73,20 @@ internal class CommunityItemFragment :
             is Event.JoinGroup -> {
                 if (category == CommunityCategory.BOARD) {
                     if (event.isSuccess) {
-                        Snackbar.make(
-                            binding.root,
-                            getString(R.string.text_join_group_success),
-                            Snackbar.LENGTH_SHORT
-                        ).show()
+                        binding.root.makeSnackBar(getString(R.string.text_join_group_success))
+                            .show()
                     } else {
-                        Snackbar.make(
-                            binding.root,
-                            getString(R.string.text_join_group_fail),
-                            Snackbar.LENGTH_SHORT
-                        ).show()
+                        binding.root.makeSnackBar(getString(R.string.text_join_group_fail)).show()
                     }
                 }
             }
             is Event.DeletePost -> {
                 if (category == CommunityCategory.MY_POST) {
                     if (event.isSuccess) {
-                        Snackbar.make(
-                            binding.root,
-                            getString(R.string.text_delete_post_success),
-                            Snackbar.LENGTH_SHORT
-                        ).show()
+                        binding.root.makeSnackBar(getString(R.string.text_delete_post_success))
+                            .show()
                     } else {
-                        Snackbar.make(
-                            binding.root,
-                            getString(R.string.text_delete_post_fail),
-                            Snackbar.LENGTH_SHORT
-                        ).show()
+                        binding.root.makeSnackBar(getString(R.string.text_delete_post_fail)).show()
                     }
                 }
             }
@@ -168,13 +154,10 @@ internal class CommunityItemFragment :
             val postAdapter = PostAdapter(
                 isMyPost = true,
                 itemLongClickListener = { postId ->
-                    Snackbar.make(
-                        binding.root,
-                        getString(R.string.text_check_delete_post),
-                        Snackbar.LENGTH_SHORT
-                    ).setAction(R.string.text_delete) {
-                        viewModel.deletePost(postId)
-                    }.show()
+                    binding.root.makeSnackBar(getString(R.string.text_check_delete_post))
+                        .setAction(R.string.text_delete) {
+                            viewModel.deletePost(postId)
+                        }.show()
                 }
             )
 

--- a/presentation/src/main/java/com/whyranoid/presentation/community/group/create/CreateGroupFragment.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/community/group/create/CreateGroupFragment.kt
@@ -9,11 +9,11 @@ import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.google.android.material.chip.Chip
-import com.google.android.material.snackbar.Snackbar
 import com.whyranoid.presentation.R
 import com.whyranoid.presentation.base.BaseFragment
 import com.whyranoid.presentation.compose.RulePicker
 import com.whyranoid.presentation.databinding.FragmentCreateGroupBinding
+import com.whyranoid.presentation.util.makeSnackBar
 import com.whyranoid.presentation.util.repeatWhenUiStarted
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -79,42 +79,22 @@ internal class CreateGroupFragment :
         when (event) {
             is Event.CreateGroupButtonClick -> {
                 if (event.isSuccess) {
-                    Snackbar.make(
-                        binding.root,
-                        getString(R.string.text_create_group_success),
-                        Snackbar.LENGTH_SHORT
-                    ).show()
+                    binding.root.makeSnackBar(getString(R.string.text_create_group_success)).show()
                     findNavController().popBackStack()
                 } else {
-                    Snackbar.make(
-                        binding.root,
-                        getString(R.string.text_create_group_fail),
-                        Snackbar.LENGTH_SHORT
-                    ).show()
+                    binding.root.makeSnackBar(getString(R.string.text_create_group_fail)).show()
                 }
             }
             is Event.DuplicateCheckButtonClick -> {
                 if (event.isDuplicatedGroupName) {
-                    Snackbar.make(
-                        binding.root,
-                        getString(R.string.text_duplicated_group_name),
-                        Snackbar.LENGTH_SHORT
-                    ).show()
+                    binding.root.makeSnackBar(getString(R.string.text_duplicated_group_name)).show()
                 } else {
-                    Snackbar.make(
-                        binding.root,
-                        getString(R.string.text_un_duplicated_group_name),
-                        Snackbar.LENGTH_SHORT
-                    ).show()
+                    binding.root.makeSnackBar(getString(R.string.text_un_duplicated_group_name)).show()
                     binding.etGroupName.isEnabled = false
                 }
             }
             is Event.WarningButtonClick -> {
-                Snackbar.make(
-                    binding.root,
-                    getString(R.string.text_warning_create_group),
-                    Snackbar.LENGTH_SHORT
-                ).show()
+                binding.root.makeSnackBar(getString(R.string.text_warning_create_group)).show()
             }
             is Event.AddRuleButtonClick -> {
                 binding.composeView.apply {

--- a/presentation/src/main/java/com/whyranoid/presentation/community/group/detail/GroupDetailFragment.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/community/group/detail/GroupDetailFragment.kt
@@ -7,10 +7,10 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
-import com.google.android.material.snackbar.Snackbar
 import com.whyranoid.presentation.R
 import com.whyranoid.presentation.base.BaseFragment
 import com.whyranoid.presentation.databinding.FragmentGroupDetailBinding
+import com.whyranoid.presentation.util.makeSnackBar
 import com.whyranoid.presentation.util.repeatWhenUiStarted
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
@@ -93,52 +93,30 @@ internal class GroupDetailFragment :
     private fun handleEvent(event: Event) {
         when (event) {
             Event.RecruitButtonClick -> {
-                Snackbar.make(
-                    binding.root,
-                    getString(R.string.text_check_recruit),
-                    Snackbar.LENGTH_SHORT
-                ).setAction(R.string.text_recruit) {
-                    viewModel.onRecruitSnackBarButtonClick()
-                }.show()
+                binding.root.makeSnackBar(getString(R.string.text_check_recruit))
+                    .setAction(R.string.text_recruit) {
+                        viewModel.onRecruitSnackBarButtonClick()
+                    }.show()
             }
             is Event.RecruitSnackBarButtonClick -> {
                 if (event.isSuccess) {
-                    Snackbar.make(
-                        binding.root,
-                        getString(R.string.text_recruit_success),
-                        Snackbar.LENGTH_SHORT
-                    ).show()
+                    binding.root.makeSnackBar(getString(R.string.text_recruit_success)).show()
                 } else {
-                    Snackbar.make(
-                        binding.root,
-                        getString(R.string.text_recruit_fail),
-                        Snackbar.LENGTH_SHORT
-                    ).show()
+                    binding.root.makeSnackBar(getString(R.string.text_recruit_fail)).show()
                 }
             }
             Event.ExitGroupButtonClick -> {
-                Snackbar.make(
-                    binding.root,
-                    getString(R.string.text_check_exit_group),
-                    Snackbar.LENGTH_SHORT
-                ).setAction(getString(R.string.text_exit_group)) {
-                    viewModel.onExitGroupSnackBarButtonClick()
-                }.show()
+                binding.root.makeSnackBar(getString(R.string.text_check_exit_group))
+                    .setAction(getString(R.string.text_exit_group)) {
+                        viewModel.onExitGroupSnackBarButtonClick()
+                    }.show()
             }
             is Event.ExitGroupSnackBarButtonClick -> {
                 if (event.isSuccess) {
-                    Snackbar.make(
-                        binding.root,
-                        getString(R.string.text_exit_group_success),
-                        Snackbar.LENGTH_SHORT
-                    ).show()
+                    binding.root.makeSnackBar(getString(R.string.text_exit_group_success)).show()
                     findNavController().popBackStack()
                 } else {
-                    Snackbar.make(
-                        binding.root,
-                        getString(R.string.text_exit_group_fail),
-                        Snackbar.LENGTH_SHORT
-                    ).show()
+                    binding.root.makeSnackBar(getString(R.string.text_exit_group_fail)).show()
                 }
             }
         }

--- a/presentation/src/main/java/com/whyranoid/presentation/community/group/edit/EditGroupFragment.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/community/group/edit/EditGroupFragment.kt
@@ -5,10 +5,10 @@ import android.view.View
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.google.android.material.chip.Chip
-import com.google.android.material.snackbar.Snackbar
 import com.whyranoid.presentation.R
 import com.whyranoid.presentation.base.BaseFragment
 import com.whyranoid.presentation.databinding.FragmentEditGroupBinding
+import com.whyranoid.presentation.util.makeSnackBar
 import com.whyranoid.presentation.util.repeatWhenUiStarted
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -33,22 +33,14 @@ internal class EditGroupFragment :
         when (event) {
             // TODO : 다이어로그로 그룹을 수정할 수 있도록 변경
             is Event.AddRuleButtonClick -> {
-                Snackbar.make(binding.root, "룰 추가 클릭", Snackbar.LENGTH_SHORT).show()
+                binding.root.makeSnackBar(getString(R.string.community_click_add_rule)).show()
             }
             is Event.EditGroupButtonClick -> {
                 if (event.isSuccess) {
-                    Snackbar.make(
-                        binding.root,
-                        getString(R.string.text_edit_group_success),
-                        Snackbar.LENGTH_SHORT
-                    ).show()
+                    binding.root.makeSnackBar(getString(R.string.text_edit_group_success)).show()
                     findNavController().popBackStack()
                 } else {
-                    Snackbar.make(
-                        binding.root,
-                        getString(R.string.text_edit_group_fail),
-                        Snackbar.LENGTH_SHORT
-                    ).show()
+                    binding.root.makeSnackBar(getString(R.string.text_edit_group_fail)).show()
                 }
             }
         }

--- a/presentation/src/main/java/com/whyranoid/presentation/community/runningpost/CreateRunningPostFragment.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/community/runningpost/CreateRunningPostFragment.kt
@@ -4,11 +4,11 @@ import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
-import com.google.android.material.snackbar.Snackbar
 import com.whyranoid.presentation.R
 import com.whyranoid.presentation.base.BaseFragment
 import com.whyranoid.presentation.databinding.FragmentCreateRunningPostBinding
 import com.whyranoid.presentation.model.UiState
+import com.whyranoid.presentation.util.makeSnackBar
 import com.whyranoid.presentation.util.repeatWhenUiStarted
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -74,12 +74,7 @@ internal class CreateRunningPostFragment :
                         true
                     }
                     R.id.warning_about_create_running_post_button -> {
-                        Snackbar.make(
-                            binding.root,
-                            getString(R.string.community_warning_running_post),
-                            Snackbar.LENGTH_SHORT
-                        )
-                            .show()
+                        binding.root.makeSnackBar(getString(R.string.community_warning_running_post))
                         true
                     }
                     else -> {
@@ -95,21 +90,10 @@ internal class CreateRunningPostFragment :
             val action =
                 CreateRunningPostFragmentDirections.actionCreateRunningPostFragmentToCommunityFragment()
 
-            Snackbar.make(
-                requireView(),
-                getString(R.string.community_success_create_running_post),
-                Snackbar.LENGTH_SHORT
-            )
-                .show()
-
+            requireView().makeSnackBar(getString(R.string.community_success_create_running_post))
             findNavController().navigate(action)
         } else {
-            Snackbar.make(
-                requireView(),
-                getString(R.string.community_fail_create_running_post),
-                Snackbar.LENGTH_SHORT
-            )
-                .show()
+            requireView().makeSnackBar(getString(R.string.community_fail_create_running_post))
         }
     }
 }

--- a/presentation/src/main/java/com/whyranoid/presentation/community/runningpost/SelectRunningHistoryFragment.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/community/runningpost/SelectRunningHistoryFragment.kt
@@ -4,12 +4,12 @@ import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
-import com.google.android.material.snackbar.Snackbar
 import com.whyranoid.presentation.R
 import com.whyranoid.presentation.base.BaseFragment
 import com.whyranoid.presentation.databinding.FragmentSelectRunningHistoryBinding
 import com.whyranoid.presentation.model.RunningHistoryUiModel
 import com.whyranoid.presentation.model.UiState
+import com.whyranoid.presentation.util.makeSnackBar
 import com.whyranoid.presentation.util.repeatWhenUiStarted
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -96,11 +96,8 @@ internal class SelectRunningHistoryFragment :
                         true
                     }
                     R.id.warning_select_running_history_button -> {
-                        Snackbar.make(
-                            binding.root,
-                            getString(R.string.community_select_running_history_snack_bar),
-                            Snackbar.LENGTH_SHORT
-                        ).show()
+                        binding.root.makeSnackBar(getString(R.string.community_select_running_history_snack_bar))
+                            .show()
                         true
                     }
                     else -> {

--- a/presentation/src/main/java/com/whyranoid/presentation/myrun/CalendarDayBinder.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/myrun/CalendarDayBinder.kt
@@ -25,8 +25,6 @@ class CalendarDayBinder(
         DayContainer(ItemCalendarDayBinding.bind(view))
 
     override fun bind(container: DayContainer, day: CalendarDay) {
-        val (startDate, endDate) = this.calendar
-
         container.binding.tvCalendarDay.text = day.date.dayOfMonth.toString()
 
         if (day.owner != DayOwner.THIS_MONTH) {
@@ -41,7 +39,7 @@ class CalendarDayBinder(
             container.binding.tvCalendarDay.setTextColor(
                 ContextCompat.getColor(
                     calendarView.context,
-                    R.color.black
+                    R.color.mogakrun_on_secondary
                 )
             )
             container.binding.root.background = null
@@ -54,20 +52,6 @@ class CalendarDayBinder(
                     R.color.gray
                 )
             )
-        }
-
-        if (startDate == day.date) {
-            container.binding.root.background =
-                ContextCompat.getDrawable(
-                    calendarView.context,
-                    R.drawable.thumbnail_src_small
-                )
-        } else if (endDate == day.date) {
-            container.binding.root.background =
-                ContextCompat.getDrawable(
-                    calendarView.context,
-                    R.drawable.thumbnail_src_small
-                )
         }
 
         runningDays.forEach { runningDay ->

--- a/presentation/src/main/java/com/whyranoid/presentation/myrun/CalendarDayBinder.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/myrun/CalendarDayBinder.kt
@@ -9,13 +9,11 @@ import com.kizitonwose.calendarview.ui.DayBinder
 import com.kizitonwose.calendarview.ui.ViewContainer
 import com.whyranoid.presentation.R
 import com.whyranoid.presentation.databinding.ItemCalendarDayBinding
-import java.time.LocalDate
 
 class CalendarDayBinder(
     private val calendarView: CalendarView,
     private val runningDays: List<List<String>>
 ) : DayBinder<CalendarDayBinder.DayContainer> {
-    private var calendar: CalendarRange = CalendarRange(null, null)
 
     class DayContainer(
         val binding: ItemCalendarDayBinding
@@ -34,7 +32,7 @@ class CalendarDayBinder(
                     R.color.gray
                 )
             )
-            // day.day와 day.date.monthValue를 지정해서 특정 월, 일에 달렸다는 콩 표시 가능
+            container.binding.root.background = null
         } else {
             container.binding.tvCalendarDay.setTextColor(
                 ContextCompat.getColor(
@@ -45,19 +43,10 @@ class CalendarDayBinder(
             container.binding.root.background = null
         }
 
-        if (isInRange(day.date)) {
-            container.binding.root.setBackgroundColor(
-                ContextCompat.getColor(
-                    calendarView.context,
-                    R.color.gray
-                )
-            )
-        }
-
         runningDays.forEach { runningDay ->
             val (runningDayYear, runningDayMonth, runningDayDay) = runningDay.map { it.toInt() }
 
-            if (runningDayYear == day.date.year && runningDayMonth == day.date.monthValue && runningDayDay == day.day) {
+            if (runningDayYear == day.date.year && runningDayMonth == day.date.monthValue && runningDayDay == day.date.dayOfMonth) {
                 container.binding.root.background =
                     ContextCompat.getDrawable(
                         calendarView.context,
@@ -66,14 +55,4 @@ class CalendarDayBinder(
             }
         }
     }
-
-    private fun isInRange(date: LocalDate): Boolean {
-        val (startDate, endDate) = this.calendar
-        return startDate == date || endDate == date || (startDate != null && endDate != null && startDate < date && date < endDate)
-    }
 }
-
-data class CalendarRange(
-    val startDate: LocalDate?,
-    val endDate: LocalDate?
-)

--- a/presentation/src/main/java/com/whyranoid/presentation/myrun/MyRunFragment.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/myrun/MyRunFragment.kt
@@ -136,7 +136,7 @@ internal class MyRunFragment : BaseFragment<FragmentMyRunBinding>(R.layout.fragm
 
     private fun onMonthScrolled(currentMonth: YearMonth) {
         val visibleMonth = binding.calendarView.findFirstVisibleMonth() ?: return
-        binding.tvMonthIndicator.text = visibleMonth.yearMonth.month.toString()
+        binding.tvMonthIndicator.text = getString(R.string.my_run_year_month_indicator, visibleMonth.yearMonth.month.toString(), visibleMonth.year.toString())
         if (currentMonth != visibleMonth.yearMonth) {
             binding.calendarView.smoothScrollToMonth(currentMonth)
         }

--- a/presentation/src/main/java/com/whyranoid/presentation/running/RunningActivity.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/running/RunningActivity.kt
@@ -4,7 +4,6 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.viewModels
-import com.google.android.material.snackbar.Snackbar
 import com.naver.maps.geometry.LatLng
 import com.naver.maps.map.CameraUpdate
 import com.naver.maps.map.LocationSource
@@ -18,6 +17,7 @@ import com.whyranoid.presentation.R
 import com.whyranoid.presentation.base.BaseActivity
 import com.whyranoid.presentation.databinding.ActivityRunningBinding
 import com.whyranoid.presentation.util.dateToString
+import com.whyranoid.presentation.util.makeSnackBar
 import com.whyranoid.presentation.util.repeatWhenUiStarted
 import com.whyranoid.runningdata.model.RunningData
 import com.whyranoid.runningdata.model.RunningFinishData
@@ -35,13 +35,10 @@ internal class RunningActivity :
 
     private val backPressedCallback = object : OnBackPressedCallback(true) {
         override fun handleOnBackPressed() {
-            Snackbar.make(
-                binding.root,
-                getString(R.string.running_finish_snackbar_content),
-                Snackbar.LENGTH_SHORT
-            ).setAction(getString(R.string.running_finish_snackbar_action)) {
-                viewModel.onFinishButtonClicked()
-            }.show()
+            binding.root.makeSnackBar(getString(R.string.running_finish_snackbar_content))
+                .setAction(getString(R.string.running_finish_snackbar_action)) {
+                    viewModel.onFinishButtonClicked()
+                }.show()
         }
     }
 

--- a/presentation/src/main/java/com/whyranoid/presentation/runningstart/RunningStartFragment.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/runningstart/RunningStartFragment.kt
@@ -12,7 +12,6 @@ import androidx.core.content.ContextCompat
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
-import com.google.android.material.snackbar.Snackbar
 import com.whyranoid.presentation.R
 import com.whyranoid.presentation.base.BaseFragment
 import com.whyranoid.presentation.databinding.FragmentRunningStartBinding
@@ -20,6 +19,7 @@ import com.whyranoid.presentation.running.RunningActivity
 import com.whyranoid.presentation.running.RunningViewModel.Companion.RUNNING_FINISH_DATA_KEY
 import com.whyranoid.presentation.util.getSerializableData
 import com.whyranoid.presentation.util.gpsstate.GPSState
+import com.whyranoid.presentation.util.makeSnackBar
 import com.whyranoid.presentation.util.repeatWhenUiStarted
 import com.whyranoid.runningdata.model.RunningFinishData
 import com.whyranoid.runningdata.model.RunningState
@@ -105,7 +105,7 @@ internal class RunningStartFragment :
                 if (GPSState.getGpsState(requireContext())) {
                     tryRunningStart()
                 } else {
-                    Snackbar.make(binding.root, "gps 켜주세요", Snackbar.LENGTH_SHORT).show()
+                    binding.root.makeSnackBar(getString(R.string.running_start_turn_on_gps)).show()
                 }
             }
         }
@@ -163,11 +163,6 @@ internal class RunningStartFragment :
                     )
                 findNavController().navigate(direction)
             }
-        } ?: Snackbar.make(
-            binding.root,
-            getString(R.string.running_start_error_message),
-            Snackbar.LENGTH_SHORT
-        )
-            .show()
+        } ?: binding.root.makeSnackBar(getString(R.string.running_start_error_message)).show()
     }
 }

--- a/presentation/src/main/java/com/whyranoid/presentation/util/Extensions.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/util/Extensions.kt
@@ -4,10 +4,12 @@ import android.content.Intent
 import android.os.Build
 import android.os.Bundle
 import android.os.Parcelable
+import android.view.View
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
+import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.launch
 import java.io.Serializable
 import java.text.SimpleDateFormat
@@ -29,6 +31,10 @@ fun Date.dateToString(format: String): String {
 fun Long.toRunningDateString(): String {
     val formatter = SimpleDateFormat("yyyy.MM.dd", Locale.getDefault())
     return formatter.format(this)
+}
+
+fun View.makeSnackBar(message: String): Snackbar {
+    return Snackbar.make(this, message, Snackbar.LENGTH_SHORT)
 }
 
 inline fun <reified T : Serializable> Intent.getSerializableData(key: String): T? = when {

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -15,6 +15,7 @@
     <string name="runner_start_suffix">함께 달리고 있습니다</string>
     <string name="runner_start_button_text">달리기</string>
     <string name="running_start_thumbnail_des">모각런 썸네일</string>
+    <string name="running_start_turn_on_gps">gps 켜주세요</string>
 
     <!-- 커뮤니티 탭 화면 -->
     <string name="text_board">게시판</string>
@@ -42,6 +43,7 @@
     <string name="text_delete">삭제</string>
     <string name="text_join_group">그룹 가입하기</string>
     <string name="text_like_count">좋아요 %d개</string>
+    <string name="community_click_add_rule">룰 추가 클릭</string>
 
     <!-- 마이런 탭 화면 -->
     <string name="my_run_tool_bar_menu_setting">설정</string>
@@ -52,6 +54,7 @@
     <string name="my_run_edit_nick_name_dialog_negative">취소</string>
     <string name="my_run_edit_nick_name_dialog_hint">20글자 이하로 입력해주세요</string>
     <string name="my_run_label_my_running_history">내 운동기록</string>
+    <string name="my_run_year_month_indicator">%s %s</string>
 
     <!-- 설정 화면 -->
     <string name="setting_connected_account">연결된 계정</string>

--- a/signin/src/main/java/com/whyranoid/signin/SignInActivity.kt
+++ b/signin/src/main/java/com/whyranoid/signin/SignInActivity.kt
@@ -14,7 +14,6 @@ import com.google.android.gms.auth.api.signin.GoogleSignInAccount
 import com.google.android.gms.auth.api.signin.GoogleSignInOptions
 import com.google.android.gms.common.api.ApiException
 import com.google.android.gms.tasks.Task
-import com.google.android.material.snackbar.Snackbar
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.GoogleAuthProvider
 import com.google.firebase.auth.ktx.auth
@@ -22,6 +21,7 @@ import com.google.firebase.ktx.Firebase
 import com.whyranoid.SignInUserInfo
 import com.whyranoid.SignInViewModel
 import com.whyranoid.presentation.MainActivity
+import com.whyranoid.presentation.util.makeSnackBar
 import com.whyranoid.signin.databinding.ActivitySignInBinding
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
@@ -64,19 +64,11 @@ class SignInActivity : AppCompatActivity() {
                         profileImgUri = account.photoUrl.toString()
                     }
                 } catch (e: ApiException) {
-                    Snackbar.make(
-                        binding.constraintLayoutSignIn,
-                        getString(R.string.sign_in_fail_network),
-                        Snackbar.LENGTH_SHORT
-                    )
+                    binding.constraintLayoutSignIn.makeSnackBar(getString(R.string.sign_in_fail_network))
                         .show()
                 }
             } else {
-                Snackbar.make(
-                    binding.constraintLayoutSignIn,
-                    getString(R.string.sign_in_fail_cancel),
-                    Snackbar.LENGTH_SHORT
-                )
+                binding.constraintLayoutSignIn.makeSnackBar(getString(R.string.sign_in_fail_cancel))
                     .show()
             }
         }
@@ -116,11 +108,8 @@ class SignInActivity : AppCompatActivity() {
 
         auth.signInWithCredential(credential).addOnCompleteListener { task ->
             if (task.isSuccessful) {
-                Snackbar.make(
-                    binding.constraintLayoutSignIn,
-                    getString(R.string.sign_in_success),
-                    Snackbar.LENGTH_SHORT
-                ).show()
+                binding.constraintLayoutSignIn.makeSnackBar(getString(R.string.sign_in_success))
+                    .show()
 
                 uid = auth.uid
                 lifecycleScope.launch {
@@ -132,11 +121,8 @@ class SignInActivity : AppCompatActivity() {
 
                 startActivity(intent)
             } else {
-                Snackbar.make(
-                    binding.constraintLayoutSignIn,
-                    getString(R.string.sign_in_fail_network),
-                    Snackbar.LENGTH_SHORT
-                ).show()
+                binding.constraintLayoutSignIn.makeSnackBar(getString(R.string.sign_in_fail_network))
+                    .show()
             }
         }
     }


### PR DESCRIPTION
## 😎 작업 내용
- snack bar 확장 함수 추가
- 캘린더 운동 안한 날짜에 콩 찍히는 버그 수정
- 캘린더에 연도 표시 추가

## 🧐 변경된 내용
- view.makeSnackbar("문자열").setAction{}.show() 형태로 스낵바 작성이 가능합니다.
- 액션이 필요없는 경우 생략하고 바로 .show()해주시면 됩니다.

## 🥳 동작 화면
- 동작 화면 없음

## 🤯 이슈 번호
- 이슈 없음
