### PR TITLE
컴포즈로 상단 스낵바 구현

### DIFF
--- a/presentation/src/main/java/com/whyranoid/presentation/community/runningpost/CreateRunningPostFragment.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/community/runningpost/CreateRunningPostFragment.kt
@@ -2,13 +2,19 @@ package com.whyranoid.presentation.community.runningpost
 
 import android.os.Bundle
 import android.view.View
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.google.android.material.snackbar.Snackbar
 import com.whyranoid.presentation.R
 import com.whyranoid.presentation.base.BaseFragment
+import com.whyranoid.presentation.compose.TopSnackBar
 import com.whyranoid.presentation.databinding.FragmentCreateRunningPostBinding
 import com.whyranoid.presentation.model.UiState
+import com.whyranoid.presentation.util.networkconnection.NetworkState
 import com.whyranoid.presentation.util.repeatWhenUiStarted
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -35,6 +41,22 @@ internal class CreateRunningPostFragment :
         binding.selectedRunningHistory = viewModel.selectedRunningHistory
         binding.executePendingBindings()
         setUpMenu()
+        binding.cvNetworkConnection.apply {
+            setViewCompositionStrategy(
+                ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed
+            )
+            setContent {
+                MaterialTheme {
+                    val showSnackBar: NetworkState by viewModel.networkState.collectAsState()
+                    TopSnackBar(
+                        isVisible =
+                        showSnackBar is NetworkState.DisConnection,
+                        text =
+                        getString(R.string.network_connection_alert)
+                    )
+                }
+            }
+        }
     }
 
     private fun observeState() {

--- a/presentation/src/main/java/com/whyranoid/presentation/compose/TopSnackBar.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/compose/TopSnackBar.kt
@@ -42,7 +42,8 @@ fun TopSnackBar(isVisible: Boolean, text: String) {
         ) {
             Text(
                 modifier = Modifier.padding(8.dp),
-                text = text
+                text = text,
+                color = colorResource(id = R.color.mogakrun_on_secondary)
             )
         }
     }

--- a/presentation/src/main/java/com/whyranoid/presentation/compose/TopSnackBar.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/compose/TopSnackBar.kt
@@ -1,0 +1,49 @@
+package com.whyranoid.presentation.compose
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.FastOutLinearInEasing
+import androidx.compose.animation.core.LinearOutSlowInEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.unit.dp
+import com.whyranoid.presentation.R
+
+@Composable
+fun TopSnackBar(isVisible: Boolean, text: String) {
+    AnimatedVisibility(
+        visible = isVisible,
+        enter = slideInVertically(
+            initialOffsetY = { fullHeight -> -fullHeight },
+            animationSpec = tween(durationMillis = 250, easing = LinearOutSlowInEasing)
+        ),
+        exit = slideOutVertically(
+            targetOffsetY = { fullHeight -> -fullHeight },
+            animationSpec = tween(durationMillis = 250, easing = FastOutLinearInEasing)
+        )
+    ) {
+        Box(
+            modifier = Modifier.fillMaxWidth()
+                .padding(8.dp)
+                .clip(shape = RoundedCornerShape(15.dp))
+                .background(color = colorResource(id = R.color.mogakrun_secondary_dark)),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                modifier = Modifier.padding(8.dp),
+                text = text
+            )
+        }
+    }
+}

--- a/presentation/src/main/res/layout/fragment_create_running_post.xml
+++ b/presentation/src/main/res/layout/fragment_create_running_post.xml
@@ -18,19 +18,6 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <TextView
-            android:id="@+id/tv_network_connection"
-            networkConnectionVisibility="@{vm.networkState}"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:background="@color/gray"
-            android:gravity="center"
-            android:padding="4dp"
-            android:text="@string/network_connection_alert"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/app_bar" />
-
         <com.google.android.material.appbar.AppBarLayout
             android:id="@+id/app_bar"
             android:layout_width="match_parent"
@@ -49,13 +36,21 @@
 
         </com.google.android.material.appbar.AppBarLayout>
 
+        <androidx.compose.ui.platform.ComposeView
+            android:id="@+id/cv_network_connection"
+            android:layout_width="0dp"
+            android:layout_height="50dp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/app_bar"/>
+
         <TextView
             android:id="@+id/tv_label_running_history"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/community_label_running_history"
             android:textAppearance="@style/MoGakRunText.Bold.Medium"
-            app:layout_constraintTop_toBottomOf="@id/tv_network_connection"
+            app:layout_constraintTop_toBottomOf="@id/app_bar"
             app:layout_constraintStart_toStartOf="parent"
             android:layout_marginTop="20dp"
             android:layout_marginStart="16dp"

--- a/presentation/src/main/res/layout/fragment_create_running_post.xml
+++ b/presentation/src/main/res/layout/fragment_create_running_post.xml
@@ -40,6 +40,7 @@
             android:id="@+id/cv_network_connection"
             android:layout_width="0dp"
             android:layout_height="50dp"
+            android:translationZ="1dp"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/app_bar"/>


### PR DESCRIPTION
## 😎 작업 내용
- 컴포즈로 네트워크 상태를 알려줄 상단 스낵바 구현(애니메이션 적용)

## 🧐 변경된 내용
- 기존에 TextView였던 네트워크 알림을 컴포즈 뷰로 변경

## 🥳 동작 화면
- 이슈가 존재할 때, exit 애니메이션
![beforeIssue](https://user-images.githubusercontent.com/90144041/206517543-6c8ecc1b-9bba-44b6-8631-c5c21c64374d.gif)

- 이슈를 해결한 후 enter 애니메이션
![afterIssue](https://user-images.githubusercontent.com/90144041/206525452-6e5cde4d-264c-4751-ad5b-8e99314e2f02.gif)

## 🤯 이슈 번호
- #91 <- 해결!!

## 🥲 비고
- 추후에 모든 뷰에 네트워크 상태와 요 뷰를 넣어서 관리해보겠습니다!
- 컴포즈 뷰를 xml에 사용하면 preview가 안되는 이슈가 있는데... 요거는 확인할 때마다 composeView를 지우고... preview를 보면 됩니다..
