### PR TITLE
Data Layer에서 ViewModelScope를 사용하지 않도록 변경

### DIFF
--- a/data/src/main/java/com/whyranoid/data/account/RunningHistoryLocalDataSourceImpl.kt
+++ b/data/src/main/java/com/whyranoid/data/account/RunningHistoryLocalDataSourceImpl.kt
@@ -22,7 +22,7 @@ class RunningHistoryLocalDataSourceImpl @Inject constructor(
     }
 
     override suspend fun saveRunningHistory(runningHistoryEntity: RunningHistoryEntity): Result<RunningHistory> {
-        return kotlin.runCatching {
+        return runCatching {
             runningHistoryDao.addRunningHistory(runningHistoryEntity)
             runningHistoryEntity.toRunningHistory()
         }

--- a/data/src/main/java/com/whyranoid/data/di/CoroutineModule.kt
+++ b/data/src/main/java/com/whyranoid/data/di/CoroutineModule.kt
@@ -1,0 +1,16 @@
+package com.whyranoid.data.di
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.Dispatchers
+
+@Module
+@InstallIn(SingletonComponent::class)
+class CoroutineModule {
+
+    @Provides
+    @IODispatcher
+    fun provideIODispatcher() = Dispatchers.IO
+}

--- a/data/src/main/java/com/whyranoid/data/di/DispatchersQualifiers.kt
+++ b/data/src/main/java/com/whyranoid/data/di/DispatchersQualifiers.kt
@@ -1,0 +1,7 @@
+package com.whyranoid.data.di
+
+import javax.inject.Qualifier
+
+@Retention(AnnotationRetention.RUNTIME)
+@Qualifier
+annotation class IODispatcher

--- a/data/src/main/java/com/whyranoid/data/group/GroupDataSourceImpl.kt
+++ b/data/src/main/java/com/whyranoid/data/group/GroupDataSourceImpl.kt
@@ -178,7 +178,7 @@ class GroupDataSourceImpl @Inject constructor(
 
     private fun getGroupInfoResponse(groupId: String): Flow<GroupInfoResponse> {
         return callbackFlow {
-            db.collection(GROUPS_COLLECTION)
+            val registration = db.collection(GROUPS_COLLECTION)
                 .document(groupId)
                 .addSnapshotListener { documentSnapshot, _ ->
                     trySend(
@@ -186,13 +186,15 @@ class GroupDataSourceImpl @Inject constructor(
                             ?: throw MoGakRunException.FileNotFoundedException
                     )
                 }
-            awaitClose()
+            awaitClose {
+                registration.remove()
+            }
         }
     }
 
     private fun getUserResponse(uid: String): Flow<UserResponse> {
         return callbackFlow {
-            db.collection(USERS_COLLECTION)
+            val registration = db.collection(USERS_COLLECTION)
                 .document(uid)
                 .addSnapshotListener { documentSnapshot, _ ->
                     trySend(
@@ -200,7 +202,9 @@ class GroupDataSourceImpl @Inject constructor(
                             ?: throw MoGakRunException.FileNotFoundedException
                     )
                 }
-            awaitClose()
+            awaitClose {
+                registration.remove()
+            }
         }
     }
 

--- a/data/src/main/java/com/whyranoid/data/group/GroupRepositoryImpl.kt
+++ b/data/src/main/java/com/whyranoid/data/group/GroupRepositoryImpl.kt
@@ -7,7 +7,6 @@ import com.whyranoid.domain.model.GroupNotification
 import com.whyranoid.domain.model.Rule
 import com.whyranoid.domain.model.RunningHistory
 import com.whyranoid.domain.repository.GroupRepository
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
@@ -21,7 +20,7 @@ class GroupRepositoryImpl @Inject constructor(
         return userDataSource.getMyGroupList(uid)
     }
 
-    override fun getMyGroupListFlow(uid: String, coroutineScope: CoroutineScope) = userDataSource.getMyGroupListFlow(uid, coroutineScope)
+    override fun getMyGroupListFlow(uid: String) = userDataSource.getMyGroupListFlow(uid)
 
     override suspend fun updateGroupInfo(
         groupId: String,

--- a/data/src/main/java/com/whyranoid/data/groupnotification/GroupNotificationDataSourceImpl.kt
+++ b/data/src/main/java/com/whyranoid/data/groupnotification/GroupNotificationDataSourceImpl.kt
@@ -13,7 +13,6 @@ import com.whyranoid.domain.model.FinishNotification
 import com.whyranoid.domain.model.GroupNotification
 import com.whyranoid.domain.model.RunningHistory
 import com.whyranoid.domain.model.StartNotification
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
@@ -22,7 +21,6 @@ import kotlinx.coroutines.flow.flattenMerge
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.tasks.await
-import kotlinx.coroutines.withContext
 import java.util.UUID
 import javax.inject.Inject
 
@@ -98,19 +96,17 @@ class GroupNotificationDataSourceImpl @Inject constructor(
     }
 
     override suspend fun notifyRunningStart(uid: String, groupIdList: List<String>) {
-        withContext(Dispatchers.IO) {
-            groupIdList.forEach { groupId ->
-                db.collection(GROUP_NOTIFICATIONS_COLLECTION)
-                    .document(groupId)
-                    .collection(START_NOTIFICATION)
-                    .document(UUID.randomUUID().toString())
-                    .set(
-                        StartNotification(
-                            startedAt = System.currentTimeMillis(),
-                            uid = uid
-                        )
+        groupIdList.forEach { groupId ->
+            db.collection(GROUP_NOTIFICATIONS_COLLECTION)
+                .document(groupId)
+                .collection(START_NOTIFICATION)
+                .document(UUID.randomUUID().toString())
+                .set(
+                    StartNotification(
+                        startedAt = System.currentTimeMillis(),
+                        uid = uid
                     )
-            }
+                )
         }
     }
 
@@ -119,19 +115,17 @@ class GroupNotificationDataSourceImpl @Inject constructor(
         runningHistory: RunningHistory,
         groupIdList: List<String>
     ) {
-        withContext(Dispatchers.IO) {
-            groupIdList.forEach { groupId ->
-                db.collection(GROUP_NOTIFICATIONS_COLLECTION)
-                    .document(groupId)
-                    .collection(FINISH_NOTIFICATION)
-                    .document(UUID.randomUUID().toString())
-                    .set(
-                        FinishNotificationResponse(
-                            uid = uid,
-                            historyId = runningHistory.historyId
-                        )
+        groupIdList.forEach { groupId ->
+            db.collection(GROUP_NOTIFICATIONS_COLLECTION)
+                .document(groupId)
+                .collection(FINISH_NOTIFICATION)
+                .document(UUID.randomUUID().toString())
+                .set(
+                    FinishNotificationResponse(
+                        uid = uid,
+                        historyId = runningHistory.historyId
                     )
-            }
+                )
         }
     }
 }

--- a/data/src/main/java/com/whyranoid/data/groupnotification/GroupNotificationDataSourceImpl.kt
+++ b/data/src/main/java/com/whyranoid/data/groupnotification/GroupNotificationDataSourceImpl.kt
@@ -40,7 +40,7 @@ class GroupNotificationDataSourceImpl @Inject constructor(
 
     private fun getGroupStartNotifications(groupId: String): Flow<List<GroupNotification>> =
         callbackFlow {
-            db.collection(GROUP_NOTIFICATIONS_COLLECTION)
+            val registration = db.collection(GROUP_NOTIFICATIONS_COLLECTION)
                 .document(groupId)
                 .collection(START_NOTIFICATION)
                 .addSnapshotListener { snapshot, error ->
@@ -53,12 +53,14 @@ class GroupNotificationDataSourceImpl @Inject constructor(
                     trySend(startNotificationList)
                 }
 
-            awaitClose()
+            awaitClose {
+                registration.remove()
+            }
         }
 
     private fun getGroupFinishNotifications(groupId: String): Flow<List<GroupNotification>> =
         callbackFlow {
-            db.collection(GROUP_NOTIFICATIONS_COLLECTION)
+            val registration = db.collection(GROUP_NOTIFICATIONS_COLLECTION)
                 .document(groupId)
                 .collection(FINISH_NOTIFICATION)
                 .addSnapshotListener { snapshot, error ->
@@ -88,7 +90,9 @@ class GroupNotificationDataSourceImpl @Inject constructor(
                     }
                 }
 
-            awaitClose()
+            awaitClose {
+                registration.remove()
+            }
         }
 
     override suspend fun notifyRunningStart(uid: String, groupIdList: List<String>) {

--- a/data/src/main/java/com/whyranoid/data/running/RunnerDataSourceImpl.kt
+++ b/data/src/main/java/com/whyranoid/data/running/RunnerDataSourceImpl.kt
@@ -12,7 +12,7 @@ import kotlin.coroutines.resume
 class RunnerDataSourceImpl(private val db: FirebaseFirestore) : RunnerDataSource {
 
     override fun getCurrentRunnerCount(): Flow<Int> = callbackFlow {
-        db.collection(CollectionId.RUNNERS_COLLECTION)
+        val registration = db.collection(CollectionId.RUNNERS_COLLECTION)
             .document(CollectionId.RUNNERS_ID)
             .addSnapshotListener { snapshot, _ ->
                 snapshot?.let {
@@ -21,7 +21,9 @@ class RunnerDataSourceImpl(private val db: FirebaseFirestore) : RunnerDataSource
                 }
             }
 
-        awaitClose()
+        awaitClose {
+            registration.remove()
+        }
     }
 
     override suspend fun startRunning(uid: String): Boolean {

--- a/data/src/main/java/com/whyranoid/data/user/UserDataSource.kt
+++ b/data/src/main/java/com/whyranoid/data/user/UserDataSource.kt
@@ -1,12 +1,11 @@
 package com.whyranoid.data.user
 
 import com.whyranoid.domain.model.GroupInfo
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 
 interface UserDataSource {
 
     suspend fun getMyGroupList(uid: String): Result<List<GroupInfo>>
 
-    fun getMyGroupListFlow(uid: String, coroutineScope: CoroutineScope): Flow<List<GroupInfo>>
+    fun getMyGroupListFlow(uid: String): Flow<List<GroupInfo>>
 }

--- a/data/src/main/java/com/whyranoid/data/user/UserDataSourceImpl.kt
+++ b/data/src/main/java/com/whyranoid/data/user/UserDataSourceImpl.kt
@@ -75,7 +75,7 @@ class UserDataSourceImpl @Inject constructor(
         uid: String
     ): Flow<List<GroupInfo>> = callbackFlow {
         val coroutineScope = CoroutineScope(dispatcher)
-        db.collection(USERS_COLLECTION)
+        val registration = db.collection(USERS_COLLECTION)
             .document(uid)
             .addSnapshotListener { documentSnapshot, _ ->
                 val myGroupInfoList = mutableListOf<GroupInfo>()
@@ -93,6 +93,7 @@ class UserDataSourceImpl @Inject constructor(
 
         awaitClose {
             coroutineScope.cancel()
+            registration.remove()
         }
     }
 

--- a/data/src/main/java/com/whyranoid/data/user/UserDataSourceImpl.kt
+++ b/data/src/main/java/com/whyranoid/data/user/UserDataSourceImpl.kt
@@ -6,6 +6,7 @@ import com.whyranoid.data.constant.CollectionId.USERS_COLLECTION
 import com.whyranoid.data.constant.Exceptions.NO_GROUP_EXCEPTION
 import com.whyranoid.data.constant.Exceptions.NO_JOINED_GROUP_EXCEPTION
 import com.whyranoid.data.constant.Exceptions.NO_USER_EXCEPTION
+import com.whyranoid.data.di.IODispatcher
 import com.whyranoid.data.model.GroupInfoResponse
 import com.whyranoid.data.model.UserResponse
 import com.whyranoid.data.model.toGroupInfo
@@ -13,7 +14,9 @@ import com.whyranoid.data.model.toUser
 import com.whyranoid.domain.model.GroupInfo
 import com.whyranoid.domain.model.User
 import com.whyranoid.domain.model.toRule
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
@@ -22,7 +25,9 @@ import kotlinx.coroutines.tasks.await
 import javax.inject.Inject
 
 class UserDataSourceImpl @Inject constructor(
-    private val db: FirebaseFirestore
+    private val db: FirebaseFirestore,
+    @IODispatcher
+    private val dispatcher: CoroutineDispatcher
 ) : UserDataSource {
 
     override suspend fun getMyGroupList(uid: String): Result<List<GroupInfo>> {
@@ -67,9 +72,9 @@ class UserDataSourceImpl @Inject constructor(
 
     // TODO: 예외처리
     override fun getMyGroupListFlow(
-        uid: String,
-        coroutineScope: CoroutineScope
+        uid: String
     ): Flow<List<GroupInfo>> = callbackFlow {
+        val coroutineScope = CoroutineScope(dispatcher)
         db.collection(USERS_COLLECTION)
             .document(uid)
             .addSnapshotListener { documentSnapshot, _ ->
@@ -77,9 +82,8 @@ class UserDataSourceImpl @Inject constructor(
                 val joinedGroupList =
                     documentSnapshot?.toObject(UserResponse::class.java)?.joinedGroupList
 
-                joinedGroupList?.forEach { groupId ->
-
-                    coroutineScope.launch {
+                coroutineScope.launch {
+                    joinedGroupList?.forEach { groupId ->
                         val groupInfo = getGroupInfo(groupId)
                         myGroupInfoList.add(groupInfo)
                         trySend(myGroupInfoList)
@@ -87,7 +91,9 @@ class UserDataSourceImpl @Inject constructor(
                 }
             }
 
-        awaitClose()
+        awaitClose {
+            coroutineScope.cancel()
+        }
     }
 
     // TODO : 예외 처리

--- a/domain/src/main/java/com/whyranoid/domain/repository/GroupRepository.kt
+++ b/domain/src/main/java/com/whyranoid/domain/repository/GroupRepository.kt
@@ -4,14 +4,13 @@ import com.whyranoid.domain.model.GroupInfo
 import com.whyranoid.domain.model.GroupNotification
 import com.whyranoid.domain.model.Rule
 import com.whyranoid.domain.model.RunningHistory
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 
 interface GroupRepository {
 
     suspend fun getMyGroupList(uid: String): Result<List<GroupInfo>>
 
-    fun getMyGroupListFlow(uid: String, coroutineScope: CoroutineScope): Flow<List<GroupInfo>>
+    fun getMyGroupListFlow(uid: String): Flow<List<GroupInfo>>
 
     // 그룹 정보 수정, 홍보 글 수정
     suspend fun updateGroupInfo(

--- a/domain/src/main/java/com/whyranoid/domain/usecase/GetMyGroupListUseCase.kt
+++ b/domain/src/main/java/com/whyranoid/domain/usecase/GetMyGroupListUseCase.kt
@@ -3,7 +3,6 @@ package com.whyranoid.domain.usecase
 import com.whyranoid.domain.model.GroupInfo
 import com.whyranoid.domain.repository.AccountRepository
 import com.whyranoid.domain.repository.GroupRepository
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
@@ -11,8 +10,8 @@ class GetMyGroupListUseCase @Inject constructor(
     private val groupRepository: GroupRepository,
     private val accountRepository: AccountRepository
 ) {
-    suspend operator fun invoke(coroutineScope: CoroutineScope): Flow<List<GroupInfo>> {
+    suspend operator fun invoke(): Flow<List<GroupInfo>> {
         val uid = accountRepository.getUid()
-        return groupRepository.getMyGroupListFlow(uid, coroutineScope)
+        return groupRepository.getMyGroupListFlow(uid)
     }
 }

--- a/presentation/src/main/java/com/whyranoid/presentation/community/CommunityViewModel.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/community/CommunityViewModel.kt
@@ -82,7 +82,7 @@ class CommunityViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
-            getMyGroupListUseCase(this).onEach { groupInfoList ->
+            getMyGroupListUseCase().onEach { groupInfoList ->
                 _myGroupList.value = groupInfoList.map { groupInfo ->
                     groupInfo.toGroupInfoUiModel()
                 }


### PR DESCRIPTION
## 😎 작업 내용
- Data Layer에서 ViewModelScope를 사용하지 않도록 변경
- IODispatcher를 주입하는 모듈 추가
- FIrestore 관련 로직 일부 수정

## 🧐 변경된 내용
- DataSource에서 직접 코루틴 스코프를 관리하도록 변경
- 단순(그룹 정보) flow FireStore에서 제공해주는 snapshots()을 사용하도록 변경
`내부적으로 callbackFlow로 구현되어있음`
- 운동 종료 알림도 snapshots()를 사용하도록 변경
- `flow가 종료되면 snapshotListener들의 등록을 해제하도록 변경`
- 불필요한 withContext 일부제거
  - RunningHistoryRemoteDataSourceImpl의 `uploadRunningHistory()` 메서드는 일시적인 오류인지.. 
  호출이 우선 잘 안되는 것 같아서 제외했습니다.

## 🥳 동작 화면
- 동작 화면 없음

## 🤯 이슈 번호
- 이슈 없음

## 🥲 비고
- [나의 생각 흐름](https://luxuriant-neighbor-e45.notion.site/SDK-suspend-reactive-70fd8ced607547b984ad0e06c1dfaf5c)
