### PR TITLE
이벤트를 관리하는 SharedFlow -> EventFlow로 변경(Community)

### DIFF
--- a/presentation/src/main/java/com/whyranoid/presentation/community/group/create/CreateGroupViewModel.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/community/group/create/CreateGroupViewModel.kt
@@ -4,12 +4,12 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.whyranoid.domain.usecase.CheckIsDuplicatedGroupNameUseCase
 import com.whyranoid.domain.usecase.CreateGroupUseCase
+import com.whyranoid.presentation.util.MutableEventFlow
+import com.whyranoid.presentation.util.asEventFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
@@ -30,8 +30,8 @@ class CreateGroupViewModel @Inject constructor(
     private val _showDialog = MutableStateFlow(false)
     val showDialog: StateFlow<Boolean> = _showDialog.asStateFlow()
 
-    private val _eventFlow = MutableSharedFlow<Event>()
-    val eventFlow = _eventFlow.asSharedFlow()
+    private val _eventFlow = MutableEventFlow<Event>()
+    val eventFlow = _eventFlow.asEventFlow()
 
     private val isNotDuplicate = MutableStateFlow(false)
 

--- a/presentation/src/main/java/com/whyranoid/presentation/community/group/detail/GroupDetailViewModel.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/community/group/detail/GroupDetailViewModel.kt
@@ -13,12 +13,12 @@ import com.whyranoid.domain.usecase.GetGroupNotificationsUseCase
 import com.whyranoid.domain.usecase.GetUidUseCase
 import com.whyranoid.presentation.model.GroupInfoUiModel
 import com.whyranoid.presentation.model.toGroupInfoUiModel
+import com.whyranoid.presentation.util.EventFlow
+import com.whyranoid.presentation.util.MutableEventFlow
+import com.whyranoid.presentation.util.asEventFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -44,9 +44,9 @@ class GroupDetailViewModel @Inject constructor(
     val groupInfo: StateFlow<GroupInfoUiModel>
         get() = _groupInfo.asStateFlow()
 
-    private val _eventFlow = MutableSharedFlow<Event>()
-    val eventFlow: SharedFlow<Event>
-        get() = _eventFlow.asSharedFlow()
+    private val _eventFlow = MutableEventFlow<Event>()
+    val eventFlow: EventFlow<Event>
+        get() = _eventFlow.asEventFlow()
 
     private val startNotification = MutableStateFlow<List<GroupNotification>>(emptyList())
     private val finishNotification = MutableStateFlow<List<GroupNotification>>(emptyList())

--- a/presentation/src/main/java/com/whyranoid/presentation/community/group/edit/EditGroupViewModel.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/community/group/edit/EditGroupViewModel.kt
@@ -6,10 +6,10 @@ import androidx.lifecycle.viewModelScope
 import com.whyranoid.domain.model.toRule
 import com.whyranoid.domain.usecase.UpdateGroupInfoUseCase
 import com.whyranoid.presentation.model.GroupInfoUiModel
+import com.whyranoid.presentation.util.MutableEventFlow
+import com.whyranoid.presentation.util.asEventFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -25,8 +25,8 @@ class EditGroupViewModel @Inject constructor(
     val groupIntroduce = MutableStateFlow<String>(initGroupInfo.introduce)
     val rules = MutableStateFlow<List<String>>(initGroupInfo.rules.map { it.toString() })
 
-    private val _eventFlow = MutableSharedFlow<Event>()
-    val eventFlow = _eventFlow.asSharedFlow()
+    private val _eventFlow = MutableEventFlow<Event>()
+    val eventFlow = _eventFlow.asEventFlow()
 
     fun onAddRuleButtonClicked() {
         emitEvent(Event.AddRuleButtonClick)

--- a/presentation/src/main/java/com/whyranoid/presentation/util/EventFlow.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/util/EventFlow.kt
@@ -1,0 +1,46 @@
+package com.whyranoid.presentation.util
+
+import com.whyranoid.presentation.util.EventFlow.Companion.DEFAULT_REPLAY
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.flow.MutableSharedFlow
+import java.util.concurrent.atomic.AtomicBoolean
+
+interface EventFlow<out T> : Flow<T> {
+
+    companion object {
+        const val DEFAULT_REPLAY = 2
+    }
+}
+
+interface MutableEventFlow<T> : EventFlow<T>, FlowCollector<T>
+
+private class EventFlowSlot<T>(val value: T) {
+
+    private val consumed = AtomicBoolean(false)
+
+    fun markConsumed() = consumed.getAndSet(true)
+}
+
+private class EventFlowImpl<T>(replay: Int) : MutableEventFlow<T> {
+
+    private val flow: MutableSharedFlow<EventFlowSlot<T>> = MutableSharedFlow(replay)
+
+    override suspend fun collect(collector: FlowCollector<T>) =
+        flow.collect { slot ->
+            if (slot.markConsumed().not()) {
+                collector.emit(slot.value)
+            }
+        }
+
+    override suspend fun emit(value: T) {
+        flow.emit(EventFlowSlot(value))
+    }
+}
+
+private class ReadOnlyEventFlow<T>(flow: EventFlow<T>) : EventFlow<T> by flow
+
+@Suppress("FunctionName")
+fun <T> MutableEventFlow(replay: Int = DEFAULT_REPLAY): MutableEventFlow<T> = EventFlowImpl(replay)
+
+fun <T> MutableEventFlow<T>.asEventFlow(): EventFlow<T> = ReadOnlyEventFlow(this)


### PR DESCRIPTION
## 😎 작업 내용
- 이벤트를 관리하는 SharedFlow -> EventFlow로 변경(Community)

## 🧐 변경된 내용
- 그룹 수정 페이지 / 그룹 상세 페이지 / 그룹 생성 페이지
  - 기존 SharedFlow 대신 EventFlow를 사용하도록 변경 

## 🥳 동작 화면
- 동작 화면 없음

## 🤯 이슈 번호
- 이슈 없음

## 🥲 비고
- CommunityItemFragment / CommunityViewModel은 세 개의 프레그먼트가 하나의 eventFlow(SharedFlow)를 공유하고 있어 현재 구현된 EventFlow로는 처리가 불가능.
