### PR TITLE
그룹 생성 페이지 개선

### DIFF
--- a/presentation/src/main/java/com/whyranoid/presentation/community/group/create/CreateGroupFragment.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/community/group/create/CreateGroupFragment.kt
@@ -110,6 +110,9 @@ internal class CreateGroupFragment :
                     }
                 }
             }
+            is Event.InvalidRule -> {
+                binding.root.makeSnackBar(getString(R.string.text_invalid_rule)).show()
+            }
         }
     }
 

--- a/presentation/src/main/java/com/whyranoid/presentation/community/group/create/CreateGroupViewModel.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/community/group/create/CreateGroupViewModel.kt
@@ -12,7 +12,6 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -56,8 +55,8 @@ class CreateGroupViewModel @Inject constructor(
     }
 
     val isDoubleCheckButtonEnable: StateFlow<Boolean>
-        get() = groupName.map { name ->
-            name?.trim()?.isNotEmpty() ?: false
+        get() = groupName.combine(isNotDuplicate) { name, isNotDuplicated ->
+            name?.trim()?.isNotEmpty() ?: false && isNotDuplicated.not()
         }.stateIn(
             scope = viewModelScope,
             initialValue = false,

--- a/presentation/src/main/java/com/whyranoid/presentation/community/group/create/CreateGroupViewModel.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/community/group/create/CreateGroupViewModel.kt
@@ -41,6 +41,8 @@ class CreateGroupViewModel @Inject constructor(
     fun onDialogConfirm(date: String, hour: String, minute: String) {
         if (date.isNotEmpty() && hour.isNotEmpty() && minute.isNotEmpty()) {
             rules.value = rules.value + listOf("$date-$hour-$minute")
+        } else {
+            emitEvent(Event.InvalidRule)
         }
 
         _showDialog.value = false
@@ -110,10 +112,9 @@ class CreateGroupViewModel @Inject constructor(
                         _eventFlow.emit(event)
                     }
                 }
-                is Event.WarningButtonClick -> {
-                    _eventFlow.emit(event)
-                }
-                is Event.AddRuleButtonClick -> {
+                is Event.WarningButtonClick,
+                is Event.AddRuleButtonClick,
+                is Event.InvalidRule -> {
                     _eventFlow.emit(event)
                 }
             }

--- a/presentation/src/main/java/com/whyranoid/presentation/community/group/create/Event.kt
+++ b/presentation/src/main/java/com/whyranoid/presentation/community/group/create/Event.kt
@@ -4,5 +4,6 @@ sealed class Event {
     data class CreateGroupButtonClick(val isSuccess: Boolean = true) : Event()
     object WarningButtonClick : Event()
     object AddRuleButtonClick : Event()
+    object InvalidRule : Event()
     data class DuplicateCheckButtonClick(val isDuplicatedGroupName: Boolean = false) : Event()
 }

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -190,5 +190,6 @@
     <string name="text_minute">분</string>
     <string name="text_confirm">확인</string>
     <string name="text_rule_picker_title">요일 및 시간을 골라주세요!!</string>
+    <string name="text_invalid_rule">유효하지 않은 규칙입니다.</string>
 
 </resources>


### PR DESCRIPTION
## 😎 작업 내용
- 그룹 생성 페이지 개선
  - 그룹 이름 중복확인을 하고 중복이 아니라면 버튼을 비활성화
  - 유효하지 않은 규칙을 생성하면 스낵바로 알림처리

## 🧐 변경된 내용
 - 그룹 이름 중복확인을 하고 중복이 아니라면 버튼을 비활성화
 - 유효하지 않은 규칙을 생성하면 스낵바로 알림처리

## 🥳 동작 화면
- 중복확인 버튼 비활성화
![doubleCheck](https://user-images.githubusercontent.com/90144041/208247738-c0a82cd9-010e-481c-a487-d3679ab9f9ca.gif)

- 유효하지 않은 규칙 처리
![invalidRule](https://user-images.githubusercontent.com/90144041/208247740-480ac74b-47d2-417c-9431-2bc9b7d6a82c.gif)

## 🤯 이슈 번호
- 이슈 없음

## 🥲 비고
- 비고 없음
